### PR TITLE
Create task for sync job status check

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -83,7 +83,7 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
     @Builder.Default
     @Schema(
             title = "Parse run result",
-            description = "Parsing run result to display duration of each task inside dbt"
+            description = "Whether to parse the run result to display the duration of each dbt node in the Gantt view"
     )
     @PluginProperty
     protected Boolean parseRunResults = true;

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -74,7 +74,7 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
     Duration pollFrequency = Duration.ofSeconds(5);
 
     @Schema(
-            title = "The max total wait duration"
+            title = "The maximum duration the task should poll for the job completion"
     )
     @PluginProperty(dynamic = false)
     @Builder.Default

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -239,7 +239,7 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
     @Getter
     public static class Output implements io.kestra.core.models.tasks.Output {
         @Schema(
-                title = "URI of a run results"
+                title = "URI of the run result"
         )
         private URI runResults;
 

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -67,7 +67,7 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
 
 
     @Schema(
-            title = "Specify frequency at which the job status will be checked"
+            title = "Specify how often the task should poll for the job status"
     )
     @PluginProperty(dynamic = false)
     @Builder.Default

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -39,7 +39,7 @@ import static java.lang.Math.max;
 @Getter
 @NoArgsConstructor
 @Schema(
-        title = "Check Job status of a running job"
+        title = "Check job status of a running job"
 )
 @Plugin(
         examples = {

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -60,7 +60,7 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
     );
 
     @Schema(
-            title = "The run id to check status for"
+            title = "The job run id to check the status for"
     )
     @PluginProperty(dynamic = true)
     Integer runId;

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -1,0 +1,249 @@
+package io.kestra.plugin.dbt.cloud;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.Await;
+import io.kestra.plugin.dbt.ResultParser;
+import io.kestra.plugin.dbt.cloud.models.JobStatusHumanizedEnum;
+import io.kestra.plugin.dbt.cloud.models.RunResponse;
+import io.kestra.plugin.dbt.cloud.models.Step;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.uri.UriTemplate;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.*;
+
+import static io.kestra.core.utils.Rethrow.throwSupplier;
+import static java.lang.Math.max;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+        title = "Check Job status of a running job"
+)
+@Plugin(
+        examples = {
+                @Example(
+                        code = {
+                                "runId: \"<your run id>\"",
+                        }
+                )
+        }
+)
+public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckStatus.Output> {
+    private static final List<JobStatusHumanizedEnum> ENDED_STATUS = List.of(
+            JobStatusHumanizedEnum.ERROR,
+            JobStatusHumanizedEnum.CANCELLED,
+            JobStatusHumanizedEnum.SUCCESS
+    );
+
+    @Schema(
+            title = "The runId to sha to check out before running this job"
+    )
+    @PluginProperty(dynamic = true)
+    Integer runId;
+
+
+    @Schema(
+            title = "Specify frequency for job state check API calls"
+    )
+    @PluginProperty(dynamic = false)
+    @Builder.Default
+    Duration pollFrequency = Duration.ofSeconds(5);
+
+    @Schema(
+            title = "The max total wait duration"
+    )
+    @PluginProperty(dynamic = false)
+    @Builder.Default
+    Duration maxDuration = Duration.ofMinutes(60);
+
+    @Builder.Default
+    @Schema(
+            title = "Parse run result",
+            description = "Parsing run result to display duration of each task inside dbt"
+    )
+    @PluginProperty
+    protected Boolean parseRunResults = true;
+
+    @Builder.Default
+    @Getter(AccessLevel.NONE)
+    private transient List<JobStatusHumanizedEnum> loggedStatus = new ArrayList<>();
+
+    @Builder.Default
+    @Getter(AccessLevel.NONE)
+    private transient Map<Integer, Integer> loggedSteps = new HashMap<>();
+
+    @Override
+    public CheckStatus.Output run(RunContext runContext) throws Exception {
+        Logger logger = runContext.logger();
+
+        // wait for end
+        RunResponse finalRunResponse = Await.until(
+                throwSupplier(() -> {
+                    Optional<RunResponse> fetchRunResponse = fetchRunResponse(
+                            runContext,
+                            runId,
+                            false
+                    );
+
+                    if (fetchRunResponse.isPresent()) {
+                        logSteps(logger, fetchRunResponse.get());
+
+                        // we rely on truncated logs to be sure
+                        boolean allLogs = fetchRunResponse.get()
+                                .getData()
+                                .getRunSteps()
+                                .stream()
+                                .filter(step -> step.getTruncatedDebugLogs() != null)
+                                .count() ==
+                                fetchRunResponse.get()
+                                        .getData()
+                                        .getRunSteps().size();
+
+                        // ended
+                        if (ENDED_STATUS.contains(fetchRunResponse.get().getData().getStatusHumanized()) && allLogs) {
+                            return fetchRunResponse.get();
+                        }
+                    }
+
+                    return null;
+                }),
+                this.pollFrequency,
+                this.maxDuration
+        );
+
+        // final response
+        logSteps(logger, finalRunResponse);
+
+        if (!finalRunResponse.getData().getStatusHumanized().equals(JobStatusHumanizedEnum.SUCCESS)) {
+            throw new Exception("Failed run with status '" + finalRunResponse.getData().getStatusHumanized() +
+                    "' after " +  finalRunResponse.getData().getDurationHumanized() + ": " + finalRunResponse
+            );
+        }
+
+        Path runResultsArtifact = downloadArtifacts(runContext, runId, "run_results.json");
+        Path manifestArtifact = downloadArtifacts(runContext, runId, "manifest.json");
+
+        if (this.parseRunResults) {
+            ResultParser.parseRunResult(runContext, runResultsArtifact.toFile());
+        }
+
+        return Output.builder()
+                .runResults(runResultsArtifact.toFile().exists() ? runContext.putTempFile(runResultsArtifact.toFile()) : null)
+                .manifest(manifestArtifact.toFile().exists() ? runContext.putTempFile(manifestArtifact.toFile()) : null)
+                .build();
+    }
+
+    private void logSteps(Logger logger, RunResponse runResponse) {
+        // status changed
+        if (!loggedStatus.contains(runResponse.getData().getStatusHumanized())) {
+            logger.debug("Status changed to '{}' after {}",
+                    runResponse.getData().getStatusHumanized(),
+                    runResponse.getData().getDurationHumanized()
+            );
+            loggedStatus.add(runResponse.getData().getStatusHumanized());
+        }
+
+        // log steps
+        for (Step step : runResponse.getData().getRunSteps()) {
+            if (!step.getLogs().isEmpty()){
+                if (!loggedSteps.containsKey(step.getId())){
+                    loggedSteps.put(step.getId(), 0);
+                }
+
+                if (step.getLogs().length() > loggedSteps.get(step.getId())) {
+                    for (String s : step.getLogs().substring(max(loggedSteps.get(step.getId()) -1, 0)).split("\n")) {
+                        logger.info("[Step {}]: {}", step.getName(), s);
+                    }
+                    loggedSteps.put(step.getId(), step.getLogs().length());
+                }
+            }
+        }
+    }
+
+    private Optional<RunResponse> fetchRunResponse(RunContext runContext, Integer id, Boolean debug) throws IllegalVariableEvaluationException {
+        return this
+                .request(
+                        runContext,
+                        HttpRequest
+                                .create(
+                                        HttpMethod.GET,
+                                        UriTemplate
+                                                .of("/api/v2/accounts/{accountId}/runs/{runId}/" +
+                                                                "?include_related=" + URLEncoder.encode(
+                                                                "[\"trigger\",\"job\"," + (debug ? "\"debug_logs\"" : "") + ",\"run_steps\", \"environment\"]",
+                                                                StandardCharsets.UTF_8
+                                                        )
+                                                )
+                                                .expand(Map.of(
+                                                        "accountId", runContext.render(this.accountId),
+                                                        "runId", id
+                                                ))
+                                ),
+                        Argument.of(RunResponse.class)
+                )
+                .getBody();
+    }
+
+    private Path downloadArtifacts(RunContext runContext, Integer runId, String path) throws IllegalVariableEvaluationException, IOException {
+        String artifact = this
+                .request(
+                        runContext,
+                        HttpRequest
+                                .create(
+                                        HttpMethod.GET,
+                                        UriTemplate
+                                                .of("/api/v2/accounts/{accountId}/runs/{runId}/artifacts/{path}")
+                                                .expand(Map.of(
+                                                        "accountId", runContext.render(this.accountId),
+                                                        "runId", runId,
+                                                        "path", path
+                                                ))
+                                ),
+                        Argument.of(String.class)
+                )
+                .getBody()
+                .orElseThrow();
+
+        Path tempFile = runContext.tempFile(".json");
+
+        Files.writeString(tempFile, artifact, StandardOpenOption.TRUNCATE_EXISTING);
+
+        return tempFile;
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+                title = "URI of a run results"
+        )
+        private URI runResults;
+
+        @Schema(
+                title = "URI of a manifest"
+        )
+        private URI manifest;
+    }
+}

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -45,6 +45,8 @@ import static java.lang.Math.max;
         examples = {
                 @Example(
                         code = {
+                                "accountId: \"<your-account>\"",
+                                "token: \"<your token>\"",
                                 "runId: \"<your run id>\"",
                         }
                 )
@@ -58,7 +60,7 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
     );
 
     @Schema(
-            title = "The runId to sha to check out before running this job"
+            title = "The run id to check status for"
     )
     @PluginProperty(dynamic = true)
     Integer runId;

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -39,7 +39,7 @@ import static java.lang.Math.max;
 @Getter
 @NoArgsConstructor
 @Schema(
-        title = "Check job status of a running job"
+        title = "Check the status of a dbt Cloud job"
 )
 @Plugin(
         examples = {

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -67,7 +67,7 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
 
 
     @Schema(
-            title = "Specify frequency for job state check API calls"
+            title = "Specify frequency at which the job status will be checked"
     )
     @PluginProperty(dynamic = false)
     @Builder.Default

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -6,11 +6,7 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.utils.Await;
-import io.kestra.plugin.dbt.ResultParser;
-import io.kestra.plugin.dbt.cloud.models.JobStatusHumanizedEnum;
 import io.kestra.plugin.dbt.cloud.models.RunResponse;
-import io.kestra.plugin.dbt.cloud.models.Step;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
@@ -21,19 +17,10 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 
-import java.io.IOException;
 import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.*;
 import javax.validation.constraints.NotNull;
-
-import static io.kestra.core.utils.Rethrow.throwSupplier;
-import static java.lang.Math.max;
 
 @SuperBuilder
 @ToString
@@ -157,14 +144,6 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     )
     @PluginProperty
     protected Boolean parseRunResults = true;
-
-    @Builder.Default
-    @Getter(AccessLevel.NONE)
-    private transient List<JobStatusHumanizedEnum> loggedStatus = new ArrayList<>();
-
-    @Builder.Default
-    @Getter(AccessLevel.NONE)
-    private transient Map<Integer, Integer> loggedSteps = new HashMap<>();
 
     @Override
     public TriggerRun.Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -58,11 +58,6 @@ import static java.lang.Math.max;
     }
 )
 public class TriggerRun extends AbstractDbtCloud implements RunnableTask<TriggerRun.Output> {
-    private static final List<JobStatusHumanizedEnum> ENDED_STATUS = List.of(
-        JobStatusHumanizedEnum.ERROR,
-        JobStatusHumanizedEnum.CANCELLED,
-        JobStatusHumanizedEnum.SUCCESS
-    );
 
     @Schema(
         title = "Numeric ID of the job"
@@ -247,6 +242,8 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
 
         CheckStatus checkStatusJob = CheckStatus.builder()
                                         .runId(runId)
+                                        .token(getToken())
+                                        .accountId(getAccountId())
                                         .pollFrequency(getPollFrequency())
                                         .maxDuration(getMaxDuration())
                                         .parseRunResults(getParseRunResults())

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -245,140 +245,20 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
                 .build();
         }
 
-        // wait for end
-        RunResponse finalRunResponse = Await.until(
-            throwSupplier(() -> {
-                Optional<RunResponse> fetchRunResponse = fetchRunResponse(
-                    runContext,
-                    runId,
-                    false
-                );
+        CheckStatus checkStatusJob = CheckStatus.builder()
+                                        .runId(runId)
+                                        .pollFrequency(getPollFrequency())
+                                        .maxDuration(getMaxDuration())
+                                        .parseRunResults(getParseRunResults())
+                                        .build();
 
-                if (fetchRunResponse.isPresent()) {
-                    logSteps(logger, fetchRunResponse.get());
-
-                    // we rely on truncated logs to be sure
-                    boolean allLogs = fetchRunResponse.get()
-                        .getData()
-                        .getRunSteps()
-                        .stream()
-                        .filter(step -> step.getTruncatedDebugLogs() != null)
-                        .count() ==
-                        fetchRunResponse.get()
-                            .getData()
-                            .getRunSteps().size();
-
-                    // ended
-                    if (ENDED_STATUS.contains(fetchRunResponse.get().getData().getStatusHumanized()) && allLogs) {
-                        return fetchRunResponse.get();
-                    }
-                }
-
-                return null;
-            }),
-            this.pollFrequency,
-            this.maxDuration
-        );
-
-        // final response
-        logSteps(logger, finalRunResponse);
-
-        if (!finalRunResponse.getData().getStatusHumanized().equals(JobStatusHumanizedEnum.SUCCESS)) {
-            throw new Exception("Failed run with status '" + finalRunResponse.getData().getStatusHumanized() +
-                "' after " +  finalRunResponse.getData().getDurationHumanized() + ": " + finalRunResponse
-            );
-        }
-
-        Path runResultsArtifact = downloadArtifacts(runContext, runId, "run_results.json");
-        Path manifestArtifact = downloadArtifacts(runContext, runId, "manifest.json");
-
-        if (this.parseRunResults) {
-            ResultParser.parseRunResult(runContext, runResultsArtifact.toFile());
-        }
+        CheckStatus.Output runOutput = checkStatusJob.run(runContext);
 
         return Output.builder()
             .runId(runId)
-            .runResults(runResultsArtifact.toFile().exists() ? runContext.putTempFile(runResultsArtifact.toFile()) : null)
-            .manifest(manifestArtifact.toFile().exists() ? runContext.putTempFile(manifestArtifact.toFile()) : null)
+            .runResults(runOutput.getRunResults())
+            .manifest(runOutput.getManifest())
             .build();
-    }
-
-    private void logSteps(Logger logger, RunResponse runResponse) {
-        // status changed
-        if (!loggedStatus.contains(runResponse.getData().getStatusHumanized())) {
-            logger.debug("Status changed to '{}' after {}",
-                runResponse.getData().getStatusHumanized(),
-                runResponse.getData().getDurationHumanized()
-            );
-            loggedStatus.add(runResponse.getData().getStatusHumanized());
-        }
-
-        // log steps
-        for (Step step : runResponse.getData().getRunSteps()) {
-            if (!step.getLogs().isEmpty()){
-                if (!loggedSteps.containsKey(step.getId())){
-                    loggedSteps.put(step.getId(), 0);
-                }
-
-                if (step.getLogs().length() > loggedSteps.get(step.getId())) {
-                    for (String s : step.getLogs().substring(max(loggedSteps.get(step.getId()) -1, 0)).split("\n")) {
-                        logger.info("[Step {}]: {}", step.getName(), s);
-                    }
-                    loggedSteps.put(step.getId(), step.getLogs().length());
-                }
-            }
-        }
-    }
-
-    private Optional<RunResponse> fetchRunResponse(RunContext runContext, Integer id, Boolean debug) throws IllegalVariableEvaluationException {
-        return this
-            .request(
-                runContext,
-                HttpRequest
-                    .create(
-                        HttpMethod.GET,
-                        UriTemplate
-                            .of("/api/v2/accounts/{accountId}/runs/{runId}/" +
-                                    "?include_related=" + URLEncoder.encode(
-                                    "[\"trigger\",\"job\"," + (debug ? "\"debug_logs\"" : "") + ",\"run_steps\", \"environment\"]",
-                                    StandardCharsets.UTF_8
-                                )
-                            )
-                            .expand(Map.of(
-                                "accountId", runContext.render(this.accountId),
-                                "runId", id
-                            ))
-                    ),
-                Argument.of(RunResponse.class)
-            )
-            .getBody();
-    }
-
-    private Path downloadArtifacts(RunContext runContext, Integer runId, String path) throws IllegalVariableEvaluationException, IOException {
-        String artifact = this
-            .request(
-                runContext,
-                HttpRequest
-                    .create(
-                        HttpMethod.GET,
-                        UriTemplate
-                            .of("/api/v2/accounts/{accountId}/runs/{runId}/artifacts/{path}")
-                            .expand(Map.of(
-                                "accountId", runContext.render(this.accountId),
-                                "runId", runId,
-                                "path", path
-                            ))
-                    ),
-                Argument.of(String.class)
-            )
-            .getBody()
-            .orElseThrow();
-
-        Path tempFile = runContext.tempFile(".json");
-
-        Files.writeString(tempFile, artifact, StandardOpenOption.TRUNCATE_EXISTING);
-
-        return tempFile;
     }
 
     @Builder

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
@@ -31,7 +31,7 @@ class CheckStatusTest {
     private String jobId;
 
     @Test
-    // @Disabled("Trial account can't trigger run through api")
+    @Disabled("Trial account can't trigger run through api")
     void run() throws Exception {
 
         RunContext runContext = runContextFactory.of(ImmutableMap.of());

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.IdUtils;
-import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -48,7 +46,6 @@ class CheckStatusTest {
                 .build();
 
         TriggerRun.Output runOutput = task.run(runContext);
-
 
         CheckStatus checkStatus = CheckStatus.builder()
                 .runId(runOutput.getRunId())

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
@@ -52,6 +52,7 @@ class CheckStatusTest {
                 .token(this.token)
                 .accountId(this.accountId)
                 .maxDuration(Duration.ofMinutes(60))
+                .parseRunResults(false)
                 .build();
 
         CheckStatus.Output checkStatusOutput = checkStatus.run(runContext);

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
@@ -49,6 +49,8 @@ class CheckStatusTest {
 
         CheckStatus checkStatus = CheckStatus.builder()
                 .runId(runOutput.getRunId())
+                .token(this.token)
+                .accountId(this.accountId)
                 .maxDuration(Duration.ofMinutes(60))
                 .build();
 

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
@@ -1,0 +1,63 @@
+package io.kestra.plugin.dbt.cloud;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@MicronautTest
+class CheckStatusTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Value("${dbt.cloud.account-id}")
+    private String accountId;
+
+    @Value("${dbt.cloud.token}")
+    private String token;
+
+    @Value("${dbt.cloud.job-id}")
+    private String jobId;
+
+    @Test
+    // @Disabled("Trial account can't trigger run through api")
+    void run() throws Exception {
+
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        TriggerRun task = TriggerRun.builder()
+                .id(IdUtils.create())
+                .type(TriggerRun.class.getName())
+                .accountId(this.accountId)
+                .wait(false)
+                .token(this.token)
+                .jobId(this.jobId)
+                .build();
+
+        TriggerRun.Output runOutput = task.run(runContext);
+
+
+        CheckStatus checkStatus = CheckStatus.builder()
+                .runId(runOutput.getRunId())
+                .maxDuration(Duration.ofMinutes(60))
+                .build();
+
+        CheckStatus.Output checkStatusOutput = checkStatus.run(runContext);
+
+        assertThat(checkStatusOutput, is(notNullValue()));
+        assertThat(checkStatusOutput.getManifest(), is(notNullValue()));
+    }
+}


### PR DESCRIPTION
Add a dbt task to check until job completed given a job run Id.

See discussion [here](https://kestra-io.slack.com/archives/C03FEC452NQ/p1695811983799489)

This would help reduce risks of failures / task resubmit generating an extra job when running long syncs.

Details:

Currently if Kestra worker fails at fetching the status when wait=True on this current plugin resubmitted task will trigger a new job instead of using the existing one

Flow will first trigger in a dedicated task, then “wait for status” will be done in a dedicated task.
If “wait for status” task fails (worker is dead / killed / pod restarted, this task can last for 10h+ so kind of likely) => task is resubmitted with the jobId to fetch for

No need for pod restart (due to k8s node upgrades for example) supervision