### PR TITLE
fix(docs): update task runner syntax in the examples

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/Build.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Build.java
@@ -33,12 +33,13 @@ import lombok.experimental.SuperBuilder;
                          type: io.kestra.plugin.git.Clone
                          url: https://github.com/kestra-io/dbt-demo
                          branch: main
+
                        - id: dbt-build
                          type: io.kestra.plugin.dbt.cli.Build
-                         runner: DOCKER
+                         taskRunner: 
+                           type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
                          dbtPath: /usr/local/bin/dbt
-                         docker:
-                           image: ghcr.io/kestra-io/dbt-duckdb
+                         containerImage: ghcr.io/kestra-io/dbt-duckdb
                          profiles: |
                            jaffle_shop:
                              outputs:

--- a/src/main/java/io/kestra/plugin/dbt/cli/Compile.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Compile.java
@@ -33,12 +33,13 @@ import lombok.experimental.SuperBuilder;
                       type: io.kestra.plugin.git.Clone
                       url: https://github.com/kestra-io/dbt-demo
                       branch: main
+
                     - id: dbt-compile
                       type: io.kestra.plugin.dbt.cli.Compile
-                      runner: DOCKER
+                      taskRunner:
+                        type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
                       dbtPath: /usr/local/bin/dbt
-                      docker:
-                        image: ghcr.io/kestra-io/dbt-duckdb
+                      containerImage: ghcr.io/kestra-io/dbt-duckdb
                       profiles: |
                         jaffle_shop:
                           outputs:

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -97,11 +97,11 @@ import jakarta.validation.constraints.NotNull;
 
                   - id: dbt
                     type: io.kestra.plugin.dbt.cli.DbtCLI
-                    runner: DOCKER
-                    docker:
-                      image: python:3.11-slim
+                    taskRunner:
+                      type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
                       memory:
                         memory: 1GB          
+                    containerImage: python:3.11-slim
                     beforeCommands:
                       - pip install uv
                       - uv venv --quiet

--- a/src/main/java/io/kestra/plugin/dbt/cli/Deps.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Deps.java
@@ -38,12 +38,13 @@ import java.nio.file.Path;
                       type: io.kestra.plugin.git.Clone
                       url: https://github.com/kestra-io/dbt-demo
                       branch: main
+
                     - id: dbt-deps
                       type: io.kestra.plugin.dbt.cli.Deps
-                      runner: DOCKER
+                      taskRunner: 
+                        type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
                       dbtPath: /usr/local/bin/dbt
-                      docker:
-                        image: ghcr.io/kestra-io/dbt-duckdb
+                      containerImage: ghcr.io/kestra-io/dbt-duckdb
                       profiles: |
                         jaffle_shop:
                           outputs:

--- a/src/main/java/io/kestra/plugin/dbt/cli/Freshness.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Freshness.java
@@ -37,12 +37,13 @@ import java.nio.file.Path;
                       type: io.kestra.plugin.git.Clone
                       url: https://github.com/kestra-io/dbt-demo
                       branch: main
+
                     - id: dbt-freshness
                       type: io.kestra.plugin.dbt.cli.Freshness
-                      runner: DOCKER
+                      taskRunner:
+                        type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
                       dbtPath: /usr/local/bin/dbt
-                      docker:
-                        image: ghcr.io/kestra-io/dbt-duckdb
+                      containerImage: ghcr.io/kestra-io/dbt-duckdb
                       profiles: |
                         jaffle_shop:
                           outputs:

--- a/src/main/java/io/kestra/plugin/dbt/cli/List.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/List.java
@@ -39,10 +39,10 @@ import java.nio.file.Path;
                       branch: main
                     - id: dbt-list
                       type: io.kestra.plugin.dbt.cli.List
-                      runner: DOCKER
+                      taskRunner:
+                        type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
                       dbtPath: /usr/local/bin/dbt
-                      docker:
-                        image: ghcr.io/kestra-io/dbt-duckdb
+                      containerImage: ghcr.io/kestra-io/dbt-duckdb
                       profiles: |
                         jaffle_shop:
                           outputs:

--- a/src/main/java/io/kestra/plugin/dbt/cli/Run.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Run.java
@@ -33,12 +33,13 @@ import lombok.experimental.SuperBuilder;
                       type: io.kestra.plugin.git.Clone
                       url: https://github.com/kestra-io/dbt-demo
                       branch: main
+
                     - id: dbt-run
                       type: io.kestra.plugin.dbt.cli.Run
-                      runner: DOCKER
+                      taskRunner:
+                        type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
                       dbtPath: /usr/local/bin/dbt
-                      docker:
-                        image: ghcr.io/kestra-io/dbt-duckdb
+                      containerImage: ghcr.io/kestra-io/dbt-duckdb
                       profiles: |
                         jaffle_shop:
                           outputs:

--- a/src/main/java/io/kestra/plugin/dbt/cli/Seed.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Seed.java
@@ -33,12 +33,13 @@ import lombok.experimental.SuperBuilder;
                       type: io.kestra.plugin.git.Clone
                       url: https://github.com/kestra-io/dbt-demo
                       branch: main
+
                     - id: dbt-seed
                       type: io.kestra.plugin.dbt.cli.Seed
-                      runner: DOCKER
+                      taskRunner:
+                        type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
                       dbtPath: /usr/local/bin/dbt
-                      docker:
-                        image: ghcr.io/kestra-io/dbt-duckdb
+                      containerImage: ghcr.io/kestra-io/dbt-duckdb
                       profiles: |
                         jaffle_shop:
                           outputs:

--- a/src/main/java/io/kestra/plugin/dbt/cli/Snapshot.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Snapshot.java
@@ -35,10 +35,10 @@ import lombok.experimental.SuperBuilder;
                       branch: main
                     - id: dbt-snapshot
                       type: io.kestra.plugin.dbt.cli.Snapshot
-                      runner: DOCKER
+                      taskRunner:
+                        type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
                       dbtPath: /usr/local/bin/dbt
-                      docker:
-                        image: ghcr.io/kestra-io/dbt-duckdb
+                      containerImage: ghcr.io/kestra-io/dbt-duckdb
                       profiles: |
                         jaffle_shop:
                           outputs:

--- a/src/main/java/io/kestra/plugin/dbt/cli/Test.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Test.java
@@ -35,10 +35,10 @@ import lombok.experimental.SuperBuilder;
                       branch: main
                     - id: dbt_test
                       type: io.kestra.plugin.dbt.cli.Test
-                      runner: DOCKER
+                      taskRunner:
+                        type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
                       dbtPath: /usr/local/bin/dbt
-                      docker:
-                        image: ghcr.io/kestra-io/dbt-duckdb
+                      containerImage: ghcr.io/kestra-io/dbt-duckdb
                       profiles: |
                         my_dbt_project:
                           outputs:


### PR DESCRIPTION
### What changes are being made and why?
- Change task runner syntax to new format as the old format is being depreciated soon.

Example:

```yaml
tasks:
  - id: example_task
    type: io.kestra.plugin.scripts.shell.Commands
    runner: DOCKER
```

to:

```yaml
tasks:
  - id: example_task
    type: io.kestra.plugin.scripts.shell.Commands
    taskRunner:
      type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
```
