### PR TITLE
fix: parsing of dynamic task duration

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/ResultParser.java
+++ b/src/main/java/io/kestra/plugin/dbt/ResultParser.java
@@ -69,7 +69,7 @@ public abstract class ResultParser {
 
                 r.getTiming()
                     .stream()
-                    .mapToLong(timing -> timing.getStartedAt().toEpochMilli())
+                    .mapToLong(timing -> timing.getCompletedAt().toEpochMilli())
                     .max()
                     .ifPresent(value -> {
                         histories.add(new State.History(


### PR DESCRIPTION
replaced forgotten getStartedAt() by getCompletedAt()

[#4767](https://github.com/kestra-io/kestra/issues/4767)
