### PR TITLE
fix(v2 property): back to v1 when annotation is different that @NotNull

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
@@ -2,7 +2,6 @@ package io.kestra.plugin.dbt.cli;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
-import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.*;

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -181,7 +181,8 @@ public class DbtCLI extends AbstractExecScript {
     )
     @NotNull
     @NotEmpty
-    private Property<List<String>> commands;
+    @PluginProperty(dynamic = true)
+    private List<String> commands;
 
     @Schema(
         title = "The `profiles.yml` file content.",
@@ -266,7 +267,7 @@ public class DbtCLI extends AbstractExecScript {
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
             this.getBeforeCommandsWithOptions(),
-            this.commands.asList(runContext, String.class).stream().map(command -> command.concat(" --log-format json")).toList()
+            runContext.render(this.commands).stream().map(command -> command.concat(" --log-format json")).toList()
         );
 
         // check that if a command uses --project-dir, the projectDir must be set

--- a/src/main/java/io/kestra/plugin/dbt/cli/Setup.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Setup.java
@@ -110,7 +110,8 @@ public class Setup extends AbstractExecScript implements RunnableTask<ScriptOutp
     )
     @NotNull
     @NotEmpty
-    private final Property<String> pythonPath = Property.of(DEFAULT_IMAGE);
+    @PluginProperty(dynamic = true)
+    private final String pythonPath = DEFAULT_IMAGE;
 
     @Schema(
         title = "List of python dependencies to add to the python execution process.",
@@ -213,7 +214,7 @@ public class Setup extends AbstractExecScript implements RunnableTask<ScriptOutp
     private List<String> virtualEnvCommand(RunContext runContext, Path workingDirectory, List<String> requirements) throws IllegalVariableEvaluationException {
         List<String> renderer = new ArrayList<>();
 
-        renderer.add(this.pythonPath.as(runContext, String.class) + " -m venv --system-site-packages " + workingDirectory + " > /dev/null");
+        renderer.add(runContext.render(this.pythonPath) + " -m venv --system-site-packages " + workingDirectory + " > /dev/null");
 
         if (requirements != null) {
             renderer.addAll(Arrays.asList(

--- a/src/test/java/io/kestra/plugin/dbt/cli/DbtCLITest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cli/DbtCLITest.java
@@ -62,7 +62,7 @@ class DbtCLITest {
                     """)
             )
             .containerImage("ghcr.io/kestra-io/dbt-bigquery:latest")
-            .commands(Property.of(List.of("dbt build")))
+            .commands(List.of("dbt build"))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, execute, Map.of());


### PR DESCRIPTION
V2 properties does not support other annotations than `@NotNull` for now. To prevent bugs we just revert the properties to v1 when other annotations are involved.

[Fixes https://github.com/kestra-io/plugin-dbt/pull/144](https://github.com/kestra-io/kestra/issues/5124)
