### PR TITLE
fix(cli): remove immutable map to avoid throwing exception

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
@@ -28,7 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -90,7 +90,7 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
     @Valid
     protected TaskRunner taskRunner = Docker.builder()
             .type(Docker.class.getName())
-            .entryPoint(Collections.emptyList())
+            .entryPoint(new ArrayList<>())
             .build();
 
     @Schema(title = "The task runner container image, only used if the task runner is container-based.")
@@ -143,7 +143,7 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
         CommandsWrapper commandsWrapper = new CommandsWrapper(runContext)
-            .withEnv(this.getEnv() != null ? this.getEnv().asMap(runContext, String.class, String.class) : Collections.emptyMap())
+            .withEnv(this.getEnv() != null ? this.getEnv().asMap(runContext, String.class, String.class) : new HashMap<>())
             .withNamespaceFiles(namespaceFiles)
             .withInputFiles(inputFiles)
             .withOutputFiles(outputFiles)

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -30,7 +30,7 @@ import java.io.File;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import jakarta.validation.constraints.NotEmpty;
@@ -214,7 +214,7 @@ public class DbtCLI extends AbstractExecScript {
     @Valid
     protected TaskRunner taskRunner = Docker.builder()
         .type(Docker.class.getName())
-        .entryPoint(Collections.emptyList())
+        .entryPoint(new ArrayList<>())
         .build();
 
     @Builder.Default
@@ -231,7 +231,7 @@ public class DbtCLI extends AbstractExecScript {
             builder.image(this.getContainerImage());
         }
         if (original.getEntryPoint() == null) {
-            builder.entryPoint(Collections.emptyList());
+            builder.entryPoint(new ArrayList<>());
         }
 
         return builder.build();

--- a/src/main/java/io/kestra/plugin/dbt/cli/Setup.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Setup.java
@@ -35,7 +35,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -193,7 +192,7 @@ public class Setup extends AbstractExecScript implements RunnableTask<ScriptOutp
             runContext,
             workingDirectory,
             this.finalInputFiles(runContext),
-            Collections.emptyMap()
+            new HashMap<>()
         );
 
         List<String> commandsArgs = ScriptService.scriptCommands(


### PR DESCRIPTION
exception threw because wrapper add env to Collections.emptyMAp()

no issues for DbtCli because this class uses the v1 plugin property
close #148
