### PR TITLE
fix: verify map not empty to avoid UnsupportedException (#171)

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
@@ -142,9 +142,10 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
         var renderedOutputFiles = runContext.render(this.outputFiles).asList(String.class);
+        var renderedEnvMap = runContext.render(this.getEnv()).asMap(String.class, String.class);
 
         CommandsWrapper commandsWrapper = new CommandsWrapper(runContext)
-            .withEnv(runContext.render(this.getEnv()).asMap(String.class, String.class))
+            .withEnv(renderedEnvMap.isEmpty() ? new HashMap<>() : renderedEnvMap)
             .withNamespaceFiles(namespaceFiles)
             .withInputFiles(inputFiles)
             .withOutputFiles(renderedOutputFiles.isEmpty() ? null : renderedOutputFiles)


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

Cherry-pick from master to pass a new HAshMap to env to avoid UnsupportedOperationException with ImmutableMap

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

Cherry-pick from master to pass a new HAshMap to env to avoid UnsupportedOperationException with ImmutableMap
### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->
