### PR TITLE
WIP feat: add support for package management

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/internals/PythonBasedPlugin.java
+++ b/src/main/java/io/kestra/plugin/dbt/internals/PythonBasedPlugin.java
@@ -1,0 +1,37 @@
+package io.kestra.plugin.dbt.internals;
+
+import io.kestra.core.models.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Interface for Python-based plugin.
+ */
+public interface PythonBasedPlugin extends Plugin {
+
+    String DEFAULT_PYTHON_VERSION = "3.13";
+    String DEFAULT_IMAGE = "python:" + DEFAULT_PYTHON_VERSION + "-slim";
+
+    @Schema(
+        title = "The script dependencies."
+    )
+    @PluginProperty
+    Property<List<String>> getDependencies();
+
+    @Schema(
+        title = "The version of Python to use for the script.",
+        description = "If no version is explicitly specified, the task will attempt to extract the version from the configured container image. If it cannot determine the version from the image, the task will default to Python '"+ DEFAULT_PYTHON_VERSION +" '"
+    )
+    @PluginProperty
+    Property<String> getPythonVersion();
+
+    @Schema(
+        title = "Enable Python dependency caching",
+        description = "When enabled, Python dependencies will be cached across task executions. This locks dependency versions and speeds up subsequent runs by avoiding redundant installations."
+    )
+    @PluginProperty
+    Property<Boolean> getDependencyCacheEnabled();
+}

--- a/src/main/java/io/kestra/plugin/dbt/internals/PythonDependenciesResolver.java
+++ b/src/main/java/io/kestra/plugin/dbt/internals/PythonDependenciesResolver.java
@@ -1,0 +1,462 @@
+package io.kestra.plugin.dbt.internals;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+import io.kestra.core.runners.WorkingDir;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Service for resolving python and installing packages.
+ */
+@Slf4j
+public class PythonDependenciesResolver {
+
+    private static final String HOME_ENV = System.getenv("HOME");
+    private static final String PATH_ENV = System.getenv("PATH");
+    private static final String WORKING_DIR_ADDITIONAL_PYTHON_LIB = ".kestra_additional_python_lib";
+
+    private final Logger logger;
+    private final WorkingDir workingDir;
+    private final Path localCacheDir;
+    private String uvCmd;
+
+    /**
+     * Creates a new {@link PythonDependenciesResolver} instance.
+     *
+     * @param workingDir The {@link WorkingDir}.
+     */
+    public PythonDependenciesResolver(final Logger logger, final WorkingDir workingDir, final Path localCacheDir) {
+        this.workingDir = Objects.requireNonNull(workingDir, "workingDir cannot be null");
+        this.logger = Objects.requireNonNull(logger, "logger cannot be null");
+        this.localCacheDir = Objects.requireNonNull(localCacheDir, "localCacheDir cannot be null");
+    }
+
+    /**
+     * Gets the path for the python interpreter.
+     *
+     * @param version The python version.
+     * @return The path to the python interpreter.
+     */
+    public String getPythonPath(final String version) {
+        Optional<String> pythonPath = findPython(version);
+        if (pythonPath.isEmpty()) {
+            installPython(version);
+            pythonPath = findPython(version);
+        }
+        return pythonPath.orElseThrow(() -> new KestraRuntimeException("Could not find or install Python '" + version + "'path"));
+    }
+
+    /**
+     * Finds the version of the local Python installation.
+     *
+     * @return an {@link Optional} containing the version string (e.g., {@code "3.12.3"})
+     *         if Python is installed and the version can be determined; otherwise, an empty {@link Optional}
+     */
+    public Optional<String> findLocalPythonVersion() {
+        Optional<String> python = findPython(null);
+        if (python.isPresent()) {
+            logger.debug("Find local python version");
+            try {
+                ExecExitStatus execExitStatus = execCommandAndGetStdOut(List.of(python.get(), "--version"));
+                if (execExitStatus.isSuccess()) {
+                    return execExitStatus.stdOuts().stream().findFirst()
+                        .map(version -> version.replaceFirst("Python ", ""));
+                }
+                return Optional.empty();
+            } catch (IOException | InterruptedException e) {
+                if (e instanceof InterruptedException)  {
+                    Thread.currentThread().interrupt();
+                }
+                throw new KestraRuntimeException("Failed to wait for '" + python.get() + " --version' command. Error " + e.getMessage());
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Restores and get the resolved pythons packages from the given input stream.
+     *
+     * @param version The python version.
+     * @param hash    The versioned requirement hash.
+     * @param stream  The {@link InputStream}.
+     * @return The {@link ResolvedPythonPackages}.
+     * @throws IOException if an error occurred while reading the {@code stream}.
+     */
+    public ResolvedPythonPackages getPythonLibs(final String version, final String hash, final InputStream stream) throws IOException {
+        final Path workingDirPath = workingDir.path();
+        try (ZipInputStream zis = new ZipInputStream(stream)) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                var fileName = entry.getName();
+
+                Path outputPath;
+                if (entry.getName().equals(ResolvedPythonPackages.REQUIREMENTS_TXT)) {
+                    fileName = getRequirementTxtFilename(hash);
+                    outputPath = workingDirPath.resolve(fileName).normalize();
+                } else {
+                    outputPath = workingDirPath.resolve(WORKING_DIR_ADDITIONAL_PYTHON_LIB).resolve(fileName).normalize();
+                }
+
+                // Prevent zip-slip vulnerability
+                if (!outputPath.startsWith(workingDirPath)) {
+                    logger.trace("Skipping entry '{}'", entry.getName());
+                    continue;
+                }
+
+                if (entry.isDirectory()) {
+                    Files.createDirectories(outputPath);
+                } else {
+                    Files.createDirectories(outputPath.getParent());
+                    try (OutputStream os = Files.newOutputStream(outputPath)) {
+                        zis.transferTo(os);
+                    }
+                }
+                zis.closeEntry();
+            }
+        }
+        return new ResolvedPythonPackages(
+            workingDir.resolve(Path.of(WORKING_DIR_ADDITIONAL_PYTHON_LIB)),
+            workingDir.resolve(Path.of(getRequirementTxtFilename(hash))),
+            hash,
+            version
+        );
+    }
+
+    private static String getRequirementTxtFilename(String hash) {
+        // Prefix with 'hash' to avoid file name collision
+        return hash + "-" + ResolvedPythonPackages.REQUIREMENTS_TXT;
+    }
+
+    public ResolvedPythonPackages getPythonLibs(final String version, final String hash, final List<String> requirements) throws IOException {
+        final String pythonPath = getPythonPath(version);
+        final Path pythonLibDir = workingDir.resolve(Path.of(WORKING_DIR_ADDITIONAL_PYTHON_LIB));
+
+        Path in = createRequirementInFileAndGetPath(version, hash, requirements);
+
+        logger.debug("Compiling dependencies");
+        Path req = workingDir.createFile(getRequirementTxtFilename(hash));
+
+        try {
+            execCommandAndGetStdOut(
+                List.of(getUvCmd(), "pip", "compile",
+                    "--quiet",
+                    "--no-color",
+                    "--no-config",
+                    "--no-header",
+                    "--strip-extras",
+                    "--output-file", req.toString(),
+                    "--python", pythonPath,
+                    "--cache-dir", getUvCacheDir(),
+                    in.toString()
+                )
+            );
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException)  {
+                Thread.currentThread().interrupt();
+            }
+            throw new KestraRuntimeException("Failed to wait for 'uv pip compile' command. Error " + e.getMessage());
+        }
+
+        logger.debug("Installing packages");
+        try {
+            execCommandAndGetStdOut(
+                List.of(getUvCmd(), "pip", "install",
+                    "--quiet",
+                    "--no-color",
+                    "--no-config",
+                    "--link-mode", "copy",
+                    "--reinstall",
+                    "--index-strategy", "unsafe-best-match",
+                    "--target=" + pythonLibDir,
+                    "--requirement=" + req,
+                    "--python", pythonPath,
+                    "--cache-dir", getUvCacheDir()
+                )
+            );
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException)  {
+                Thread.currentThread().interrupt();
+            }
+            throw new KestraRuntimeException("Failed to wait for uv pip install command. Error " + e.getMessage());
+        }
+        return new ResolvedPythonPackages(pythonLibDir, req, hash, version);
+    }
+
+    public Path createRequirementInFileAndGetPath(String version, String hash, List<String> requirements) throws IOException {
+        // prefix with hash to avoid file name collision
+        Path in = workingDir.createFile(hash + "-" + ResolvedPythonPackages.REQUIREMENTS_IN);
+        Files.write(in, normalizeRequirements(version, requirements), StandardCharsets.UTF_8);
+        return in;
+    }
+
+    /**
+     * Computes the SHA-256 hash for the given python version and dependencies requirements.
+     * <p>
+     * The returned hash key can be used as cached-key.
+     *
+     * @param version      The python version.
+     * @param requirements The python package requirements.
+     * @return the SHA-256 hash.
+     */
+    public String getRequirementsHashKey(final String version, final List<String> requirements) {
+        List<String> inReqList = normalizeRequirements(version, requirements);
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            for (String line : inReqList) {
+                digest.update(line.getBytes(StandardCharsets.UTF_8));
+            }
+            byte[] bytes = digest.digest();
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new KestraRuntimeException(e);
+        }
+    }
+
+    private List<String> normalizeRequirements(String version, List<String> requirements) {
+        List<String> inReqList = new ArrayList<>(requirements);
+        Collections.sort(requirements);
+        inReqList.addFirst("#pyversion: " + version);
+        return inReqList;
+    }
+
+    private ExecExitStatus execCommandAndGetStdOut(List<String> command) throws IOException, InterruptedException {
+        return execCommandAndGetStdOut(command, null);
+    }
+
+    private ExecExitStatus execCommandAndGetStdOut(List<String> command, Function<ProcessBuilder, ProcessBuilder> modifier) throws IOException, InterruptedException {
+        logger.debug("Executing command: {}", String.join(" ", command));
+        ProcessBuilder builder = new ProcessBuilder(command)
+            .redirectErrorStream(false); // keep stderr separate for error handling
+
+        if (modifier != null) {
+            builder = modifier.apply(builder);
+        }
+
+        Process process = builder.start();
+
+        List<String> outs = new ArrayList<>();
+        Thread stdoutLogger = Thread.ofVirtual().name("python-dep-resolver-log-out")
+            .start(() -> logStream(process.getInputStream(), false, outs::add));
+
+        Thread stderrLogger = Thread.ofVirtual().name("python-dep-resolver-log-err")
+            .start(() -> logStream(process.getErrorStream(), true));
+
+        int exitCode = process.waitFor();
+
+        stdoutLogger.join();
+        stderrLogger.join();
+
+        return new ExecExitStatus(exitCode, outs);
+    }
+
+    private String getUvCmd() {
+        if (this.uvCmd != null) {
+            return this.uvCmd;
+        }
+
+        this.uvCmd = "uv";
+        try {
+            String uvPath = Optional.ofNullable(System.getenv("UV_PATH")).orElse("$HOME/.local/bin/uv".replace("$HOME", HOME_ENV));
+            if (Files.exists(Path.of(uvPath))) {
+                this.uvCmd = uvPath;
+            }
+        } catch (SecurityException ignore) {
+            // Failed to check the path of 'uv'.
+            // Ignore the exception because 'uv' will be installed below if necessary.
+        }
+
+        logger.debug("Finding uv command");
+        String version = null;
+        try {
+            version = getUvVersion(uvCmd);
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException)  {
+                Thread.currentThread().interrupt();
+            }
+        }
+        if (version == null) {
+            logger.warn(
+                "Unable to detect an installed version of 'uv'. " +
+                    "Attempting to install 'uv' from: https://astral.sh/uv/install.sh. " +
+                    "Please make sure 'uv' is installed and available on all Kestra workers."
+            );
+            Path script = null;
+            try {
+                script = workingDir.createFile("install-uv.sh");
+                try (InputStream in = URI.create("https://astral.sh/uv/install.sh").toURL().openStream()) {
+                    Files.copy(in, script, StandardCopyOption.REPLACE_EXISTING);
+                }
+                execCommandAndGetStdOut(List.of("chmod", "+x", script.toString()));
+                execCommandAndGetStdOut(List.of("sh", script.toString()), builder -> {
+                        Map<String, String> env = builder.environment();
+                        env.clear();
+                        env.put("HOME", HOME_ENV);
+                        env.put("PATH", PATH_ENV);
+                        env.put("UV_INSTALL_DIR", workingDir.path().toString());
+                        env.put("UV_NO_MODIFY_PATH", "true");
+                        return builder;
+                    }
+                );
+                this.uvCmd = workingDir.resolve(Path.of("uv")).toString();
+                version = getUvVersion(uvCmd);
+            } catch (IOException | InterruptedException e) {
+                if (e instanceof InterruptedException)  {
+                    Thread.currentThread().interrupt();
+                }
+                logger.debug("Failed to install uv", e);
+            } finally {
+                if (script != null) {
+                    try {
+                        Files.deleteIfExists(script);
+                    } catch (IOException ignore) {
+                    }
+                }
+            }
+        }
+        if (version != null) {
+            logger.debug("Use uv: {}", version);
+        }
+        return this.uvCmd;
+    }
+
+    private String getUvVersion(String uvCmd) throws IOException, InterruptedException {
+        ExecExitStatus execStatus = execCommandAndGetStdOut(List.of(uvCmd, "--version"), null);
+        return execStatus.isSuccess() ? execStatus.stdOuts.getFirst() : null;
+    }
+
+    private boolean installPython(String version) {
+        logger.debug("Installing Python '{}' environment", version);
+
+        // Only use managed Python installations; never use system Python installations
+        List<String> command = List.of(
+            getUvCmd(),
+            "python",
+            "install",
+            version,
+            "--python-preference=only-managed"
+        );
+
+        final ExecExitStatus exec;
+        try {
+            exec = execCommandAndGetStdOut(command, builder -> {
+                // Clear and set environment
+                Map<String, String> env = builder.environment();
+                env.clear();
+                env.put("HOME", HOME_ENV);
+                env.put("PATH", PATH_ENV);
+                env.put("UV_PYTHON_INSTALL_DIR", localCacheDir.resolve("python").toString());
+                env.put("UV_CACHE_DIR", localCacheDir.resolve("uv").toString());
+
+                return builder;
+            });
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException)  {
+                Thread.currentThread().interrupt();
+            }
+            throw new KestraRuntimeException("Failed to wait for 'uv python install' command. Error " + e.getMessage());
+        }
+        return exec.isSuccess();
+    }
+
+    private Optional<String> findPython(final String version) {
+
+        List<String> command;
+        if (version != null) {
+            logger.debug("Finding Python '{}' interpreter.", version);
+            command = List.of(
+                getUvCmd(), "python", "find", version, "--system", "--python-preference=only-managed"
+            );
+        } else {
+            command = List.of(
+                getUvCmd(), "python", "find", "--system", "--no-managed-python"
+            );
+        }
+
+        final ExecExitStatus exec;
+        try {
+            exec = execCommandAndGetStdOut(command, builder -> {
+                // Clear and set only needed environment variables
+                Map<String, String> env = builder.environment();
+                env.clear();
+                env.put("HOME", HOME_ENV);
+                env.put("PATH", PATH_ENV);
+                env.put("UV_PYTHON_INSTALL_DIR", getUvPythonInstallDir());
+                if (version != null) {
+                    env.put("UV_PYTHON_PREFERENCE", "only-managed");
+                }
+                env.put("UV_CACHE_DIR", getUvCacheDir());
+
+                return builder;
+            });
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException)  {
+                Thread.currentThread().interrupt();
+            }
+            throw new KestraRuntimeException("Failed to wait for 'uv python find' command. Error " + e.getMessage());
+        }
+
+        if (exec.isSuccess()) {
+            return exec.stdOuts().stream().findFirst();
+        }
+        return Optional.empty();
+    }
+
+    private String getUvPythonInstallDir() {
+        return localCacheDir.resolve("python").toString();
+    }
+
+    private String getUvCacheDir() {
+        return localCacheDir.resolve("uv").toString();
+    }
+
+    private void logStream(InputStream stream, boolean isStdErr) {
+        logStream(stream, isStdErr, null);
+    }
+
+    private void logStream(InputStream stream, boolean isStdErr, Consumer<String> listener) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (listener != null) {
+                    listener.accept(line);
+                }
+                if (isStdErr && line.contains("error")) {
+                    // 'uv' writes debug log in stderr
+                    logger.debug(line);
+                } else {
+                    logger.debug(line);
+                }
+            }
+        } catch (IOException e) {
+            logger.error("Error logging stream: {}", isStdErr ? "stderr" : "stdout", e);
+        }
+    }
+
+    record ExecExitStatus(int exitCode, List<String> stdOuts) {
+        public boolean isSuccess() { return exitCode == 0; }
+    }
+}

--- a/src/main/java/io/kestra/plugin/dbt/internals/PythonEnvironmentManager.java
+++ b/src/main/java/io/kestra/plugin/dbt/internals/PythonEnvironmentManager.java
@@ -1,0 +1,142 @@
+package io.kestra.plugin.dbt.internals;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.executions.metrics.Timer;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.runners.TaskRunner;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.core.runner.Process;
+import io.kestra.plugin.scripts.exec.scripts.models.RunnerType;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.kestra.plugin.dbt.internals.PythonBasedPlugin.DEFAULT_IMAGE;
+import static io.kestra.plugin.dbt.internals.PythonBasedPlugin.DEFAULT_PYTHON_VERSION;
+
+public class PythonEnvironmentManager {
+
+    private final PythonBasedPlugin plugin;
+    private final RunContext runContext;
+    private final boolean isDependencyCacheEnabled;
+    private final String pythonVersion;
+
+    /**
+     * Creates a new {@link PythonBasedPlugin} instance.
+     *
+     * @param plugin The plugin for which the environment will be managed.
+     */
+    public PythonEnvironmentManager(final RunContext runContext,
+                                    final PythonBasedPlugin plugin) throws IllegalVariableEvaluationException {
+        this.plugin = plugin;
+        this.runContext = runContext;
+        this.isDependencyCacheEnabled = runContext.render(this.plugin.getDependencyCacheEnabled()).as(Boolean.class).orElse(true);
+        this.pythonVersion = runContext.render(this.plugin.getPythonVersion()).as(String.class).orElse(null);
+    }
+
+    public ResolvedPythonEnvironment setup(final Property<String> containerImage, final TaskRunner<?> taskRunner, final RunnerType runnerType) throws IllegalVariableEvaluationException, IOException {
+        List<String> requirements = new ArrayList<>(runContext.render(plugin.getDependencies()).asList(String.class));
+
+        final Path localCacheDir = getLocalCacheDir();
+        final PythonDependenciesResolver resolver = new PythonDependenciesResolver(runContext.logger(), runContext.workingDir(), localCacheDir);
+
+        final String targetPythonVersion = getTargetPythonVersion(containerImage, taskRunner, runnerType)
+            .or(resolver::findLocalPythonVersion)
+            .orElseGet(this::logAndGetPythonDefaultVersion);
+
+        final String hash = resolver.getRequirementsHashKey(targetPythonVersion, requirements);
+
+        boolean cached = false;
+        ResolvedPythonPackages resolvedPythonPackages = null;
+        if (!requirements.isEmpty()) {
+            final long metricCacheDownloadStart = System.currentTimeMillis();
+
+            Optional<InputStream> cacheFile = isDependencyCacheEnabled ? runContext.storage().getCacheFile("python-" + plugin.getType(), hash) : Optional.empty();
+
+            if (cacheFile.isPresent()) {
+                runContext.logger().debug("Restoring python dependencies cache for key: {}", hash);
+                resolvedPythonPackages = resolver.getPythonLibs(targetPythonVersion, hash, cacheFile.get());
+                runContext.logger().debug("Cache restored successfully");
+                runContext.metric(Timer.of("task.pythondeps.cache.download.duration", Duration.ofMillis(System.currentTimeMillis() - metricCacheDownloadStart)));
+                cached = true;
+            } else {
+                if (isDependencyCacheEnabled) {
+                    runContext.logger().debug("Could not find python dependencies cache for key: {}", hash);
+                }
+                resolvedPythonPackages = resolver.getPythonLibs(targetPythonVersion, hash, requirements);
+            }
+            runContext.logger().debug("Installed dependencies: {}", resolvedPythonPackages.packagesToString());
+        }
+
+        String pythonInterpreter = "python";
+        if (pythonVersion != null && (taskRunner instanceof Process || RunnerType.PROCESS.equals(runnerType))) {
+            pythonInterpreter = resolver.getPythonPath(targetPythonVersion);
+        }
+
+        return new ResolvedPythonEnvironment(cached, resolvedPythonPackages, pythonInterpreter);
+    }
+
+    private String logAndGetPythonDefaultVersion() {
+        runContext.logger().warn("No Python Version found. Using default: '{}'", DEFAULT_IMAGE);
+        return DEFAULT_PYTHON_VERSION;
+    }
+
+    private Path getLocalCacheDir() {
+        return ((DefaultRunContext) runContext).getApplicationContext().getEnvironment().getProperty("kestra.tasks.tmp-dir.path", String.class)
+            .map(Path::of)
+            .orElse(Path.of(System.getProperty("java.io.tmpdir")));
+    }
+
+    public boolean isCacheEnabled() {
+        return isDependencyCacheEnabled;
+    }
+
+    public void uploadCache(final RunContext runContext, final ResolvedPythonPackages resolvedPythonPackages) {
+        try {
+            final long start = System.currentTimeMillis();
+            runContext.logger().debug("Uploading python dependencies cache for key: {}", resolvedPythonPackages.hash());
+            File cache = resolvedPythonPackages.toZippedArchive(runContext.workingDir());
+            runContext.storage().putCacheFile(cache, "python-" + this.plugin.getType(), resolvedPythonPackages.hash());
+            runContext.logger().debug("Cache uploaded successfully (size: {} bytes)", cache.length());
+            runContext.metric(Timer.of("task.pythondeps.cache.upload.duration", Duration.ofMillis(System.currentTimeMillis() - start)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Optional<String> getTargetPythonVersion(final Property<String> containerImage, final TaskRunner<?> taskRunner, final RunnerType runnerType) throws IllegalVariableEvaluationException {
+        String pyVersion = null;
+        if (pythonVersion != null) {
+            pyVersion = pythonVersion;
+        } else if (!(taskRunner instanceof Process || RunnerType.PROCESS.equals(runnerType))) {
+            String container = runContext.render(containerImage).as(String.class).orElse(null);
+            pyVersion = PythonVersionParser.parsePyVersionFromDockerImage(container).orElse(null);
+            if (pyVersion == null) {
+                pyVersion = logAndGetPythonDefaultVersion();
+            }
+        }
+        return Optional.ofNullable(pyVersion);
+    }
+
+    /**
+     * Resolved Python Environment with Interpreter and Packages.
+     *
+     * @param cached      whether the python packages was resolved from cache.
+     * @param packages    the python packages
+     * @param interpreter the python interpreter.
+     */
+    public record ResolvedPythonEnvironment(
+        boolean cached,
+        ResolvedPythonPackages packages,
+        String interpreter
+    ) {
+    }
+}

--- a/src/main/java/io/kestra/plugin/dbt/internals/PythonVersionParser.java
+++ b/src/main/java/io/kestra/plugin/dbt/internals/PythonVersionParser.java
@@ -1,0 +1,19 @@
+package io.kestra.plugin.dbt.internals;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PythonVersionParser {
+
+    private static final Pattern PYTHON_DOCKER_IMAGE_PATTERN = Pattern.compile("python:([0-9]+(?:\\.[0-9]+){0,2})");
+
+    public static Optional<String> parsePyVersionFromDockerImage(String imageName) {
+        Matcher matcher = PYTHON_DOCKER_IMAGE_PATTERN.matcher(imageName);
+        if (matcher.find()) {
+            return Optional.of(matcher.group(1));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/io/kestra/plugin/dbt/internals/ResolvedPythonPackages.java
+++ b/src/main/java/io/kestra/plugin/dbt/internals/ResolvedPythonPackages.java
@@ -1,0 +1,71 @@
+package io.kestra.plugin.dbt.internals;
+
+import io.kestra.core.runners.WorkingDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ *
+ * @param path      the path to python packages.
+ * @param lockFile  the requirements locked file.
+ * @param hash      the hash associated to the packages.
+ * @param version   the python version.
+ */
+public record ResolvedPythonPackages(
+    Path path,
+    Path lockFile,
+    String hash,
+    String version
+) {
+
+    public static final String REQUIREMENTS_TXT = "requirements.txt";
+    public static final String REQUIREMENTS_IN = "requirements.in";
+
+    public File toZippedArchive(final WorkingDir workingDir) throws IOException {
+        Path tempFile = workingDir.createTempFile("python-" + this.version() + "-cache.zip");
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(tempFile))) {
+            ZipEntry reqZipEntry = new ZipEntry(REQUIREMENTS_TXT);
+            zos.putNextEntry(reqZipEntry);
+            Files.copy(this.lockFile(), zos);
+            zos.closeEntry();
+            Files.walkFileTree(this.path(), new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Path relativePath = path().relativize(file);
+                    ZipEntry zipEntry = new ZipEntry(relativePath.toString().replace("\\", "/"));
+                    zos.putNextEntry(zipEntry);
+                    Files.copy(file, zos);
+                    zos.closeEntry();
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    Path relativePath = path().relativize(dir);
+                    if (!relativePath.toString().isEmpty()) {
+                        ZipEntry dirEntry = new ZipEntry(relativePath.toString().replace("\\", "/") + "/");
+                        zos.putNextEntry(dirEntry);
+                        zos.closeEntry();
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        return tempFile.toFile();
+    }
+
+    public String packagesToString() throws IOException {
+        return Files.readAllLines(lockFile()).stream()
+            .filter(line -> !line.trim().startsWith("#"))
+            .collect(Collectors.joining(", "));
+    }
+}


### PR DESCRIPTION
Add support for installing and managing declared Python packages on all Dbt tasks and DbtCLI

Add new task properties `dependencies`, `pythonVersion` and `dependencyCacheEnabled`.

Related-to: kestra-io/kestra-ee#3530

To work this PR needs to add the following to the beforeCommand:

```
# 1 ) Replace all shebang to use container python interpreter
for i in {{workingDir}}/.kestra_additional_python_lib/bin/*; do [ -f "$i" ] && sed -i '1s|^#!.*|#!/usr/bin/env python|' "$i"; done

# 2 ) Make all scripts executable
for i in {{workingDir}}/.kestra_additional_python_lib/bin/*; do chmod u+x $i; done

# 3 ) Add python scripts to PATH
export PATH=$PATH:{{workingDir}}/.kestra_additional_python_lib/bin/
```
