### PR TITLE
feat(cli): support to allow changing the flow state to warning

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @SuperBuilder
 @ToString
@@ -157,11 +158,11 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
             .withLogConsumer(new AbstractLogConsumer() {
                 @Override
                 public void accept(String line, Boolean isStdErr, Instant instant) {
-                    LogService.parse(runContext, line);
+                    LogService.parse(runContext, line, new AtomicBoolean(false));
                 }
                 @Override
                 public void accept(String line, Boolean isStdErr) {
-                    LogService.parse(runContext, line);
+                    LogService.parse(runContext, line, new AtomicBoolean(false));
                 }
             })
             .withEnableOutputDirectory(true); //force output files on task runners

--- a/src/main/java/io/kestra/plugin/dbt/cli/LogService.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/LogService.java
@@ -8,13 +8,14 @@ import io.kestra.core.serializers.JacksonMapper;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class LogService {
     static final protected ObjectMapper MAPPER = JacksonMapper.ofJson()
         .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
     @SuppressWarnings("unchecked")
-    protected static void parse(RunContext runContext, String line) {
+    protected static void parse(RunContext runContext, String line, AtomicBoolean hasWarning) {
         try {
             Map<String, Object> jsonLog = (Map<String, Object>) MAPPER.readValue(line, Object.class);
 
@@ -85,6 +86,7 @@ class LogService {
                     runContext.logger().info(format, (Object[]) args);
                     break;
                 case "warn":
+                    hasWarning.set(true);
                     runContext.logger().warn(format, (Object[]) args);
                     break;
                 default:

--- a/src/test/java/io/kestra/plugin/dbt/cli/DbtCLITest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cli/DbtCLITest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.dbt.cli;
 
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
@@ -160,8 +161,37 @@ class DbtCLITest {
         assertThat(runOutputLoad.getExitCode(), is(0));
     }
 
+    @Test
+    void run_withWarning_shouldReturnWarningState() throws Exception {
+        DbtCLI execute = DbtCLI.builder()
+            .id(IdUtils.create())
+            .type(DbtCLI.class.getName())
+            .profiles(Property.of(PROFILES))
+            .containerImage(new Property<>("ghcr.io/kestra-io/dbt-bigquery:latest"))
+            .commands(Property.of(List.of(
+                "dbt deps",
+                "dbt run-operation emit_warning_log"
+            )))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, execute, Map.of());
+
+        Path workingDir = runContext.workingDir().path(true);
+        copyFolder(Path.of(Objects.requireNonNull(this.getClass().getClassLoader().getResource("project")).getPath()), workingDir);
+        createSaFile(workingDir);
+
+        DbtCLI.Output runOutput = execute.run(runContext);
+
+        assertThat("dbt command should succeed with exit code 0", runOutput.getExitCode(), is(0));
+        assertThat("warningDetected flag should be true", runOutput.isWarningDetected(), is(true));
+        assertThat("finalState should be present", runOutput.finalState().isPresent(), is(true));
+        assertThat("finalState should be WARNING", runOutput.finalState().get(), is(State.Type.WARNING));
+    }
+
     private void createSaFile(Path workingDir) throws IOException {
-        Path existingSa = Path.of(System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
+        Path existingSa = Path.of(Objects.requireNonNull(
+            this.getClass().getClassLoader().getResource("unit.json")
+        ).getPath());
         Path workingDirSa = workingDir.resolve("sa.json");
         Files.copy(existingSa, workingDirSa);
     }

--- a/src/test/java/io/kestra/plugin/dbt/cli/DbtCLITest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cli/DbtCLITest.java
@@ -189,9 +189,7 @@ class DbtCLITest {
     }
 
     private void createSaFile(Path workingDir) throws IOException {
-        Path existingSa = Path.of(Objects.requireNonNull(
-            this.getClass().getClassLoader().getResource("unit.json")
-        ).getPath());
+        Path existingSa = Path.of(System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
         Path workingDirSa = workingDir.resolve("sa.json");
         Files.copy(existingSa, workingDirSa);
     }

--- a/src/test/resources/project/macros/emit_warning.sql
+++ b/src/test/resources/project/macros/emit_warning.sql
@@ -1,0 +1,3 @@
+{% macro emit_warning_log() %}
+    {% do exceptions.warn("This is a test warning from dbt") %}
+{% endmacro %}


### PR DESCRIPTION
Adds support to allow changing flow state acc. to logs level. i.e `WARNING`

```yaml
id: dbt_warn
namespace: company.team

tasks:
  - id: dbt
    type: io.kestra.plugin.core.flow.WorkingDirectory
    tasks:
      - id: clone_repository
        type: io.kestra.plugin.git.Clone
        url: https://github.com/kestra-io/dbt-demo
        branch: warn

      - id: dbt_build
        type: io.kestra.plugin.dbt.cli.DbtCLI
        taskRunner:
          type: io.kestra.plugin.scripts.runner.docker.Docker
        containerImage: ghcr.io/kestra-io/dbt-duckdb:latest
        commands:
          - dbt deps
          - dbt build
```

<img width="1440" alt="Screenshot 2025-06-23 at 6 39 59 PM" src="https://github.com/user-attachments/assets/67ebc319-2a99-4081-adb2-f4955e8b6f46" />
<img width="1440" alt="Screenshot 2025-06-23 at 6 42 32 PM" src="https://github.com/user-attachments/assets/d95b9023-8c68-413e-a41c-324d6dee98eb" />




closes #189

Note: this requires core change, so it wont compile unless below PR is merged
- https://github.com/kestra-io/kestra/pull/9674