### PR TITLE
docs(dbt): make lowercase in titles and descriptions

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/package-info.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/package-info.java
@@ -1,7 +1,7 @@
 @PluginSubGroup(
-    title = "DBT CLI",
-    description = "This sub-group of plugins contains tasks for using DBT with its CLI.\n" +
-        "DBT is a data transformation tool that enables data analysts and engineers to transform, test and document data in the cloud data warehouse.",
+    title = "dbt CLI",
+    description = "This sub-group of plugins contains tasks for using dbt with its CLI.\n" +
+        "dbt is a data transformation tool that enables data analysts and engineers to transform, test and document data in the cloud data warehouse.",
     categories = PluginSubGroup.PluginCategory.TOOL
 )
 package io.kestra.plugin.dbt.cli;

--- a/src/main/java/io/kestra/plugin/dbt/cloud/package-info.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/package-info.java
@@ -1,7 +1,7 @@
 @PluginSubGroup(
-    title = "DBT Cloud",
-    description = "This sub-group of plugins contains tasks for using DBT Cloud.\n" +
-        "DBT is a data transformation tool that enables data analysts and engineers to transform, test and document data in the cloud data warehouse.",
+    title = "dbt Cloud",
+    description = "This sub-group of plugins contains tasks for using dbt Cloud.\n" +
+        "dbt is a data transformation tool that enables data analysts and engineers to transform, test and document data in the cloud data warehouse.",
     categories = PluginSubGroup.PluginCategory.TOOL
 )
 package io.kestra.plugin.dbt.cloud;


### PR DESCRIPTION
I think dbt is meant to be lowercase when written out generally (https://www.getdbt.com/). It would be good to align with this where we can outside of Java class names or wherever it is harder to control.