### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
@@ -90,7 +90,7 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
             If you change from the default one, be careful to also configure the entrypoint to an empty list if needed."""
     )
     @Builder.Default
-    @PluginProperty
+    @PluginProperty(group = "execution")
     @Valid
     protected TaskRunner<?> taskRunner = Docker.builder()
         .type(Docker.class.getName())
@@ -99,6 +99,7 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
 
     @Schema(title = "The task runner container image, only used if the task runner is container-based.")
     @Builder.Default
+    @PluginProperty(group = "execution")
     protected Property<String> containerImage = Property.ofValue(DEFAULT_IMAGE);
 
     @Schema(
@@ -106,16 +107,19 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
         description = "Deprecated, use 'taskRunner' instead."
     )
     @Deprecated
+    @PluginProperty(group = "execution")
     protected Property<RunnerType> runner;
 
     @Schema(
         title = "Deprecated, use 'taskRunner' instead"
     )
     @Deprecated
+    @PluginProperty(group = "execution")
     private Property<DockerOptions> docker;
 
     @Schema(title = "Deprecated, use the `docker` property instead", deprecated = true)
     @Deprecated
+    @PluginProperty(group = "advanced")
     private Property<DockerOptions> dockerOptions;
 
     @JsonSetter
@@ -127,6 +131,7 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
     @Schema(
         title = "Additional environment variables for the current process."
     )
+    @PluginProperty(group = "execution")
     protected Property<Map<String, String>> env;
 
     @Builder.Default
@@ -134,6 +139,7 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
         title = "Parse run result",
         description = "Parsing run result to display duration of each task inside dbt"
     )
+    @PluginProperty(group = "advanced")
     protected Property<Boolean> parseRunResults = Property.ofValue(Boolean.TRUE);
 
     private NamespaceFiles namespaceFiles;

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -312,18 +312,21 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
         description = "Ordered CLI commands. Lines starting with `dbt` inherit `--project-dir` when `projectDir` is set and append `--log-format` unless `logFormat` is `NONE`."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<String>> commands;
 
     @Schema(
         title = "Inline dbt profiles.yml",
         description = "Content written to `profiles.yml` in the working directory, overriding any existing file."
     )
+    @PluginProperty(group = "source")
     private Property<String> profiles;
 
     @Schema(
         title = "dbt project directory",
         description = "Relative path to the project when it differs from the working directory. Added automatically to dbt commands as `--project-dir`."
     )
+    @PluginProperty(group = "connection")
     private Property<String> projectDir;
 
     @Builder.Default
@@ -331,13 +334,14 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
         title = "Parse run results",
         description = "If true (default), reads `target/run_results.json` to expose durations and warnings in task outputs."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Boolean> parseRunResults = Property.ofValue(Boolean.TRUE);
 
     @Schema(
         title = "Task runner",
         description = "Runner configuration for executing commands. Default is Docker with an empty entrypoint; adjust entrypoint when switching runners."
     )
-    @PluginProperty
+    @PluginProperty(group = "execution")
     @Builder.Default
     @Valid
     protected TaskRunner<?> taskRunner = Docker.builder()
@@ -346,18 +350,21 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
         .build();
 
     @Builder.Default
+    @PluginProperty(group = "execution")
     protected Property<String> containerImage = Property.ofValue(CORE_IMAGE);
 
     @Schema(
         title = "Store manifest",
         description = "Persists `target/manifest.json` to the KV Store under the provided namespace/key after the run completes."
     )
+    @PluginProperty(group = "destination")
     protected KvStoreManifest storeManifest;
 
     @Schema(
         title = "Load manifest",
         description = "Fetches an existing `manifest.json` from the KV Store and writes it to `target/manifest.json` (under `projectDir` when set) before running commands; logs a warning if absent."
     )
+    @PluginProperty(group = "advanced")
     protected KvStoreManifest loadManifest;
 
     @Schema(
@@ -365,6 +372,7 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
         description = "Adds `--log-format <value>` to dbt commands unless set to `NONE`. Default JSON; supports JSON, DEBUG, TEXT, or NONE."
     )
     @Builder.Default
+    @PluginProperty(group = "processing")
     private Property<LogFormat> logFormat = Property.ofValue(LogFormat.JSON);
 
     @Schema(
@@ -372,6 +380,7 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
         description = "Selects the fallback image when none is set on the task or runner: CORE → `ghcr.io/kestra-io/dbt` (default), FUSION → `ghcr.io/kestra-io/dbt-fusion`."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Engine> engine = Property.ofValue(Engine.CORE);
 
     @Override

--- a/src/main/java/io/kestra/plugin/dbt/cli/Setup.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/Setup.java
@@ -104,7 +104,7 @@ public class Setup extends AbstractExecScript implements RunnableTask<ScriptOutp
     )
     @NotNull
     @NotEmpty
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "execution")
     private final String pythonPath = DEFAULT_IMAGE;
 
     @Schema(
@@ -112,6 +112,7 @@ public class Setup extends AbstractExecScript implements RunnableTask<ScriptOutp
         description = "Python dependencies list to setup in the virtualenv, in the same format than requirements.txt. It must at least provides dbt."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<List<String>> requirements;
 
     @Builder.Default
@@ -123,6 +124,7 @@ public class Setup extends AbstractExecScript implements RunnableTask<ScriptOutp
     )
     @NotNull
     @Deprecated(since = "0.16.0", forRemoval = true)
+    @PluginProperty(group = "deprecated")
     protected Property<Boolean> exitOnFailed = Property.ofValue(Boolean.TRUE);
 
     @Schema(
@@ -130,6 +132,7 @@ public class Setup extends AbstractExecScript implements RunnableTask<ScriptOutp
         description = "You can define the files as map or a JSON string. " +
             "Each file can be defined inlined or can reference a file from Kestra's internal storage."
     )
+    @PluginProperty(group = "source")
     private Property<Object> inputFiles;
 
     @Schema(
@@ -137,15 +140,17 @@ public class Setup extends AbstractExecScript implements RunnableTask<ScriptOutp
         description = "Task runners are provided by plugins, each have their own properties."
     )
     @Builder.Default
-    @PluginProperty
+    @PluginProperty(group = "execution")
     @Valid
     protected TaskRunner<?> taskRunner = Docker.instance();
 
     @Builder.Default
+    @PluginProperty(group = "execution")
     protected Property<String> containerImage = Property.ofValue(DEFAULT_IMAGE);
 
     @Schema(title = "Deprecated, use the `docker` property instead", deprecated = true)
     @Deprecated
+    @PluginProperty(group = "deprecated")
     private Property<DockerOptions> dockerOptions;
 
     @JsonSetter

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -36,6 +36,7 @@ import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwSupplier;
 import static java.lang.Math.max;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -97,6 +98,7 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
         title = "Parse run results",
         description = "If true (default), parses `run_results.json` to expose node timings; otherwise uploads the artifact as-is."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Boolean> parseRunResults = Property.ofValue(Boolean.TRUE);
 
     @Builder.Default

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -25,6 +25,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -150,6 +151,7 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
         title = "Parse run results",
         description = "If true (default), parses dbt run results to expose node durations and warnings."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Boolean> parseRunResults = Property.ofValue(Boolean.TRUE);
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712