### PR TITLE
fix(dbt): expose script output vars from DbtCLI

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
@@ -6,10 +6,8 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.*;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.io.FileUtils;
 
@@ -19,7 +17,6 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.*;
-import io.kestra.core.models.tasks.runners.AbstractLogConsumer;
 import io.kestra.core.models.tasks.runners.ScriptService;
 import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.runners.RunContext;
@@ -164,17 +161,7 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
             .withDockerOptions(runContext.render(this.getDocker()).as(DockerOptions.class).orElse(null))
             .withContainerImage(runContext.render(this.getContainerImage()).as(String.class).orElseThrow())
             .withTaskRunner(this.taskRunner)
-            .withLogConsumer(new AbstractLogConsumer() {
-                @Override
-                public void accept(String line, Boolean isStdErr, Instant instant) {
-                    LogService.parse(runContext, line, new AtomicBoolean(false));
-                }
-
-                @Override
-                public void accept(String line, Boolean isStdErr) {
-                    LogService.parse(runContext, line, new AtomicBoolean(false));
-                }
-            })
+            .withLogConsumer(new DbtLogConsumer(runContext))
             .withEnableOutputDirectory(true); //force output files on task runners
         Path workingDirectory = commandsWrapper.getWorkingDirectory();
 

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -6,7 +6,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -25,7 +24,6 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.RunnableTaskException;
-import io.kestra.core.models.tasks.runners.AbstractLogConsumer;
 import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
@@ -426,17 +424,7 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
 
         CommandsWrapper commandsWrapper = this.commands(runContext)
             .withEnableOutputDirectory(true) // force the output dir, so we can get the run_results.json and manifest.json files on each task runners
-            .withLogConsumer(new AbstractLogConsumer() {
-                @Override
-                public void accept(String line, Boolean isStdErr, Instant instant) {
-                    LogService.parse(runContext, line, hasWarning);
-                }
-
-                @Override
-                public void accept(String line, Boolean isStdErr) {
-                    LogService.parse(runContext, line, hasWarning);
-                }
-            });
+            .withLogConsumer(new DbtLogConsumer(runContext, hasWarning));
 
         var rProjectDir = runContext.render(projectDir).as(String.class);
         Path projectWorkingDirectory = rProjectDir
@@ -529,6 +517,7 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
             .warningDetected(hasWarning.get())
             .outputFiles(runResults.getOutputFiles())
             .exitCode(runResults.getExitCode())
+            .vars(runResults.getVars())
             .build();
     }
 

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtLogConsumer.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtLogConsumer.java
@@ -1,0 +1,44 @@
+package io.kestra.plugin.dbt.cli;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.kestra.core.models.tasks.runners.AbstractLogConsumer;
+import io.kestra.core.models.tasks.runners.PluginUtilsService;
+import io.kestra.core.runners.RunContext;
+
+/**
+ * Routes a line to one of two parsers:
+ * - `::{...}::` output markers go to {@link PluginUtilsService#parseOut} so vars are exposed on the task output.
+ * - everything else goes to {@link LogService#parse} for dbt-specific structured JSON logging.
+ *
+ * Calling both for every line would double-log non-marker lines, since `parseOut` logs the raw line
+ * when no marker is found and `LogService.parse` also logs.
+ */
+class DbtLogConsumer extends AbstractLogConsumer {
+    private final RunContext runContext;
+    private final AtomicBoolean hasWarning;
+
+    DbtLogConsumer(RunContext runContext) {
+        this(runContext, new AtomicBoolean(false));
+    }
+
+    DbtLogConsumer(RunContext runContext, AtomicBoolean hasWarning) {
+        this.runContext = runContext;
+        this.hasWarning = hasWarning;
+    }
+
+    @Override
+    public void accept(String line, Boolean isStdErr, Instant instant) {
+        if (line != null && line.startsWith("::{") && line.endsWith("}::")) {
+            this.outputs.putAll(PluginUtilsService.parseOut(line, runContext.logger(), runContext, isStdErr, instant));
+            return;
+        }
+        LogService.parse(runContext, line, hasWarning);
+    }
+
+    @Override
+    public void accept(String line, Boolean isStdErr) {
+        this.accept(line, isStdErr, null);
+    }
+}

--- a/src/test/java/io/kestra/plugin/dbt/cli/DbtCLITest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cli/DbtCLITest.java
@@ -327,6 +327,28 @@ class DbtCLITest {
     }
 
     @Test
+    void run_withOutputMarker_shouldPopulateVars() throws Exception {
+        DbtCLI task = DbtCLI.builder()
+            .id(IdUtils.create())
+            .type(DbtCLI.class.getName())
+            .taskRunner(Process.instance())
+            .commands(
+                Property.ofValue(
+                    List.of("echo '::{\"outputs\":{\"some_value\":\"hello\"}}::'")
+                )
+            )
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+
+        DbtCLI.Output output = task.run(runContext);
+
+        assertThat(output.getExitCode(), is(0));
+        assertThat(output.getVars(), is(notNullValue()));
+        assertThat(output.getVars(), hasEntry("some_value", "hello"));
+    }
+
+    @Test
     void run_withProjectDir_shouldInjectProjectDirFlag() throws Exception {
         DbtCLI task = DbtCLI.builder()
             .id(IdUtils.create())


### PR DESCRIPTION
- closes #254 

```yaml
id: chinchilla_189950
namespace: company.team

tasks:
  - id: dbt
    type: io.kestra.plugin.dbt.cli.DbtCLI
    commands:
      - "echo ::{\\\"outputs\\\": {\\\"some_value\\\": true}}::"
```


<img width="1069" height="500" alt="Screenshot 2026-05-04 at 3 36 51 PM" src="https://github.com/user-attachments/assets/58d626fd-b30f-4286-bcb5-aebcd8556676" />
