### PR TITLE
fix(plugin-dbt): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/package-info.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "dbt CLI",
+    title = "Dbt CLI",
     description = "This sub-group of plugins contains tasks for using dbt with its CLI.\n" +
         "dbt is a data transformation tool that enables data analysts and engineers to transform, test and document data in the cloud data warehouse.",
     categories = {

--- a/src/main/java/io/kestra/plugin/dbt/cloud/package-info.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "dbt Cloud",
+    title = "Dbt Cloud",
     description = "This sub-group of plugins contains tasks for using dbt Cloud.\n" +
         "dbt is a data transformation tool that enables data analysts and engineers to transform, test and document data in the cloud data warehouse.",
     categories = {


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge