### PR TITLE
feat: dbt Core v2.0 (Fusion engine) compatibility

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/AbstractRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/AbstractRun.java
@@ -74,7 +74,7 @@ public abstract class AbstractRun extends AbstractDbt {
         }
 
         if (runContext.render(this.selector).as(String.class).isPresent()) {
-            commands.add("--selector " + runContext.render(this.target).as(String.class).get());
+            commands.add("--selector " + runContext.render(this.selector).as(String.class).get());
         }
 
         if (!runContext.render(this.select).asList(String.class).isEmpty()) {

--- a/src/main/java/io/kestra/plugin/dbt/cli/AbstractRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/AbstractRun.java
@@ -36,7 +36,10 @@ public abstract class AbstractRun extends AbstractDbt {
     Property<String> target;
 
     @Schema(
-        title = "The selector name to use, as defined in selectors.yml"
+        title = "The selector name to use, as defined in selectors.yml",
+        description = """
+            Prior to v1.6.2, this property incorrectly passed the `target` value to `--selector` instead of the selector \
+            value — if your flow relied on that broken behavior, update it to use the `target` property instead."""
     )
     Property<String> selector;
 

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -280,7 +280,7 @@ import lombok.experimental.SuperBuilder;
                 """
         ),
         @Example(
-            title = "Run dbt build using the Fusion engine (dbt Core v2.0). The `engine: FUSION` property selects the `ghcr.io/kestra-io/dbt-fusion` image automatically when no `containerImage` is set. Note that `--no-partial-parse` / `--partial-parse` flags are silently ignored by Fusion and should not be used.",
+            title = "Run dbt build using the Fusion engine (dbt Core v2.0). The `engine: FUSION` property selects the `ghcr.io/kestra-io/dbt-fusion` image automatically when no `containerImage` is set. Note that `--no-partial-parse` / `--partial-parse` flags are silently ignored by Fusion and should not be used. The `ghcr.io/kestra-io/dbt-fusion` image currently ships dbt-fusion 1.11.7; full Fusion v2.0 flag compatibility (e.g. `--resource-types` plural form) will apply once the image is updated to dbt-fusion v2.0 GA.",
             full = true,
             code = """
                 id: dbt_fusion_build

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -230,10 +230,10 @@ import lombok.experimental.SuperBuilder;
                   - id: dbt_command
                     type: SELECT
                     allowCustomValue: true
-                    defaults: dbt build --project-dir dbt --target prod --no-partial-parse
+                    defaults: dbt build --project-dir dbt --target prod
                     values:
-                      - dbt build --target prod --no-partial-parse
-                      - dbt build --target prod --no-partial-parse --select state:modified+ --defer --state ./target
+                      - dbt build --target prod
+                      - dbt build --target prod --select state:modified+ --defer --state ./target
 
                 tasks:
                   - id: dbt
@@ -276,6 +276,39 @@ import lombok.experimental.SuperBuilder;
                                 fixed_retries: 1
                                 threads: 16
                                 timeout_seconds: 300
+                            target: dev
+                """
+        ),
+        @Example(
+            title = "Run dbt build using the Fusion engine (dbt Core v2.0). The `engine: FUSION` property selects the `ghcr.io/kestra-io/dbt-fusion` image automatically when no `containerImage` is set. Note that `--no-partial-parse` / `--partial-parse` flags are silently ignored by Fusion and should not be used.",
+            full = true,
+            code = """
+                id: dbt_fusion_build
+                namespace: company.team
+
+                tasks:
+                  - id: dbt
+                    type: io.kestra.plugin.core.flow.WorkingDirectory
+                    tasks:
+                      - id: clone_repository
+                        type: io.kestra.plugin.git.Clone
+                        url: https://github.com/kestra-io/dbt-example
+                        branch: main
+
+                      - id: dbt_build
+                        type: io.kestra.plugin.dbt.cli.DbtCLI
+                        engine: FUSION
+                        taskRunner:
+                          type: io.kestra.plugin.scripts.runner.docker.Docker
+                        commands:
+                          - dbt deps
+                          - dbt build
+                        profiles: |
+                          my_dbt_project:
+                            outputs:
+                              dev:
+                                type: duckdb
+                                path: ":memory:"
                             target: dev
                 """
         )
@@ -375,7 +408,11 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
 
     @Schema(
         title = "dbt engine",
-        description = "Selects the fallback image when none is set on the task or runner: CORE → `ghcr.io/kestra-io/dbt` (default), FUSION → `ghcr.io/kestra-io/dbt-fusion`."
+        description = """
+            Selects the fallback image when none is set on the task or runner: \
+            CORE → `ghcr.io/kestra-io/dbt` (default), FUSION → `ghcr.io/kestra-io/dbt-fusion`.
+            When using FUSION (dbt Core v2.0), the `--no-partial-parse` and `--partial-parse` \
+            flags are silently ignored and should be omitted from commands."""
     )
     @Builder.Default
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -33,7 +33,6 @@ import io.kestra.core.storages.kv.KVValueAndMetadata;
 import io.kestra.plugin.dbt.ResultParser;
 import io.kestra.plugin.dbt.models.Manifest;
 import io.kestra.plugin.scripts.exec.AbstractExecScript;
-import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
 import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
 import io.kestra.plugin.scripts.runner.docker.Docker;
@@ -280,7 +279,7 @@ import lombok.experimental.SuperBuilder;
                 """
         ),
         @Example(
-            title = "Run dbt build using the Fusion engine (dbt Core v2.0). The `engine: FUSION` property selects the `ghcr.io/kestra-io/dbt-fusion` image automatically when no `containerImage` is set. Note that `--no-partial-parse` / `--partial-parse` flags are silently ignored by Fusion and should not be used. The `ghcr.io/kestra-io/dbt-fusion` image currently ships dbt-fusion 1.11.7; full Fusion v2.0 flag compatibility (e.g. `--resource-types` plural form) will apply once the image is updated to dbt-fusion v2.0 GA.",
+            title = "Run dbt build using the Fusion engine (dbt Core v2.0). The `engine: FUSION` property selects the `ghcr.io/kestra-io/dbt-fusion` image automatically when no `containerImage` is set. Note that `--no-partial-parse` / `--partial-parse` flags are not supported by Fusion and should be omitted from commands. With the `duckdb` adapter, Fusion requires an explicit `database` in the profile (unlike dbt Core, which infers it from the `:memory:` path).",
             full = true,
             code = """
                 id: dbt_fusion_build
@@ -309,6 +308,7 @@ import lombok.experimental.SuperBuilder;
                               dev:
                                 type: duckdb
                                 path: ":memory:"
+                                database: memory
                             target: dev
                 """
         )
@@ -380,10 +380,9 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
         .entryPoint(new ArrayList<>())
         .build();
 
-    @Builder.Default
     @PluginProperty(group = "execution")
     @Schema(title = "The task runner container image, only used if the task runner is container-based.")
-    protected Property<String> containerImage = Property.ofValue(CORE_IMAGE);
+    protected Property<String> containerImage;
 
     @Schema(
         title = "Store manifest",
@@ -420,31 +419,6 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
     private Property<Engine> engine = Property.ofValue(Engine.CORE);
 
     @Override
-    protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
-        if (original == null) {
-            return null;
-        }
-
-        var builder = original.toBuilder();
-        if (original.getImage() == null) {
-            var rContainerImage = runContext.render(this.containerImage).as(String.class).orElse(null);
-
-            if (rContainerImage != null) {
-                builder.image(rContainerImage);
-            } else {
-                var rEngine = runContext.render(this.engine).as(Engine.class).orElse(Engine.CORE);
-                builder.image(rEngine == Engine.FUSION ? FUSION_IMAGE : CORE_IMAGE);
-            }
-        }
-
-        if (original.getEntryPoint() == null) {
-            builder.entryPoint(new ArrayList<>());
-        }
-
-        return builder.build();
-    }
-
-    @Override
     public Output run(RunContext runContext) throws Exception {
         var logger = runContext.logger();
 
@@ -460,9 +434,15 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
             );
         }
 
-        CommandsWrapper commandsWrapper = this.commands(runContext)
+        var rEngine = runContext.render(this.engine).as(Engine.class).orElse(Engine.CORE);
+
+        CommandsWrapper builtCommandsWrapper = this.commands(runContext)
             .withEnableOutputDirectory(true) // force the output dir, so we can get the run_results.json and manifest.json files on each task runners
             .withLogConsumer(new DbtLogConsumer(runContext, hasWarning));
+
+        final CommandsWrapper commandsWrapper = builtCommandsWrapper.getContainerImage() == null
+            ? builtCommandsWrapper.withContainerImage(rEngine == Engine.FUSION ? FUSION_IMAGE : CORE_IMAGE)
+            : builtCommandsWrapper;
 
         var rProjectDir = runContext.render(projectDir).as(String.class);
         Path projectWorkingDirectory = rProjectDir
@@ -490,7 +470,6 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
 
         var rCommands = runContext.render(this.commands).asList(String.class);
 
-        var rEngine = runContext.render(this.engine).as(Engine.class).orElse(Engine.CORE);
         if (rEngine == Engine.FUSION && rCommands.stream().anyMatch(command -> command.contains("--partial-parse") || command.contains("--no-partial-parse"))) {
             logger.warn("The '--partial-parse' and '--no-partial-parse' flags are not supported by the FUSION engine and will be silently ignored by dbt.");
         }

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -230,10 +230,10 @@ import lombok.experimental.SuperBuilder;
                   - id: dbt_command
                     type: SELECT
                     allowCustomValue: true
-                    defaults: dbt build --project-dir dbt --target prod --no-partial-parse
+                    defaults: dbt build --project-dir dbt --target prod
                     values:
-                      - dbt build --target prod --no-partial-parse
-                      - dbt build --target prod --no-partial-parse --select state:modified+ --defer --state ./target
+                      - dbt build --target prod
+                      - dbt build --target prod --select state:modified+ --defer --state ./target
 
                 tasks:
                   - id: dbt
@@ -276,6 +276,39 @@ import lombok.experimental.SuperBuilder;
                                 fixed_retries: 1
                                 threads: 16
                                 timeout_seconds: 300
+                            target: dev
+                """
+        ),
+        @Example(
+            title = "Run dbt build using the Fusion engine (dbt Core v2.0). The `engine: FUSION` property selects the `ghcr.io/kestra-io/dbt-fusion` image automatically when no `containerImage` is set. Note that `--no-partial-parse` / `--partial-parse` flags are silently ignored by Fusion and should not be used.",
+            full = true,
+            code = """
+                id: dbt_fusion_build
+                namespace: company.team
+
+                tasks:
+                  - id: dbt
+                    type: io.kestra.plugin.core.flow.WorkingDirectory
+                    tasks:
+                      - id: clone_repository
+                        type: io.kestra.plugin.git.Clone
+                        url: https://github.com/kestra-io/dbt-example
+                        branch: main
+
+                      - id: dbt_build
+                        type: io.kestra.plugin.dbt.cli.DbtCLI
+                        engine: FUSION
+                        taskRunner:
+                          type: io.kestra.plugin.scripts.runner.docker.Docker
+                        commands:
+                          - dbt deps
+                          - dbt build
+                        profiles: |
+                          my_dbt_project:
+                            outputs:
+                              dev:
+                                type: duckdb
+                                path: ":memory:"
                             target: dev
                 """
         )
@@ -376,7 +409,11 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
 
     @Schema(
         title = "dbt engine",
-        description = "Selects the fallback image when none is set on the task or runner: CORE → `ghcr.io/kestra-io/dbt` (default), FUSION → `ghcr.io/kestra-io/dbt-fusion`."
+        description = """
+            Selects the fallback image when none is set on the task or runner: \
+            CORE → `ghcr.io/kestra-io/dbt` (default), FUSION → `ghcr.io/kestra-io/dbt-fusion`.
+            When using FUSION (dbt Core v2.0), the `--no-partial-parse` and `--partial-parse` \
+            flags are silently ignored and should be omitted from commands."""
     )
     @Builder.Default
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -490,6 +490,11 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
 
         var rCommands = runContext.render(this.commands).asList(String.class);
 
+        var rEngine = runContext.render(this.engine).as(Engine.class).orElse(Engine.CORE);
+        if (rEngine == Engine.FUSION && rCommands.stream().anyMatch(command -> command.contains("--partial-parse") || command.contains("--no-partial-parse"))) {
+            logger.warn("The '--partial-parse' and '--no-partial-parse' flags are not supported by the FUSION engine and will be silently ignored by dbt.");
+        }
+
         LogFormat rLogFormat = runContext.render(this.logFormat).as(LogFormat.class).orElseThrow();
 
         final String logPathArg = " --log-path logs";

--- a/src/main/java/io/kestra/plugin/dbt/cli/LogService.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/LogService.java
@@ -48,6 +48,7 @@ class LogService {
                 thread = (String) jsonLog.get("thread_name");
                 type = (String) jsonLog.get("name");
                 msg = (String) jsonLog.get("message");
+                additional.putAll(jsonLog);
             } else {
                 // Legacy flat JSON log format
                 level = (String) jsonLog.get("level");
@@ -62,7 +63,6 @@ class LogService {
             additional.remove("invocation_id");
             additional.remove("level");
             additional.remove("log_version");
-            additional.remove("code");
             additional.remove("msg");
             additional.remove("message");
             additional.remove("thread");

--- a/src/main/java/io/kestra/plugin/dbt/cli/LogService.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/LogService.java
@@ -17,6 +17,9 @@ class LogService {
 
     @SuppressWarnings("unchecked")
     protected static void parse(RunContext runContext, String line, AtomicBoolean hasWarning) {
+        if (line == null) {
+            return;
+        }
         try {
             Map<String, Object> jsonLog = (Map<String, Object>) MAPPER.readValue(line, Object.class);
 
@@ -28,6 +31,7 @@ class LogService {
             HashMap<String, Object> additional = new HashMap<>();
 
             if (jsonLog.containsKey("info")) {
+                // Classic dbt JSON log format: { "info": { "level": ..., "ts": ..., ... }, "data": { ... } }
                 Map<String, Object> infoLog = (Map<String, Object>) jsonLog.get("info");
 
                 level = (String) infoLog.get("level");
@@ -37,7 +41,15 @@ class LogService {
                 msg = (String) infoLog.get("msg");
 
                 additional.putAll(infoLog);
+            } else if (jsonLog.containsKey("message")) {
+                // Fusion v2.0 JSON log format: { "level": ..., "ts": ..., "message": ..., ... }
+                level = normalizeLevel((String) jsonLog.get("level"));
+                ts = (String) jsonLog.get("ts");
+                thread = (String) jsonLog.get("thread_name");
+                type = (String) jsonLog.get("name");
+                msg = (String) jsonLog.get("message");
             } else {
+                // Legacy flat JSON log format
                 level = (String) jsonLog.get("level");
                 ts = (String) jsonLog.get("ts");
                 thread = (String) jsonLog.get("thread_name");
@@ -52,6 +64,7 @@ class LogService {
             additional.remove("log_version");
             additional.remove("code");
             additional.remove("msg");
+            additional.remove("message");
             additional.remove("thread");
             additional.remove("thread_name");
             additional.remove("type");
@@ -79,6 +92,11 @@ class LogService {
                 }
             }
 
+            if (level == null) {
+                runContext.logger().info(format, (Object[]) args);
+                return;
+            }
+
             switch (level) {
                 case "debug":
                     runContext.logger().debug(format, (Object[]) args);
@@ -96,5 +114,20 @@ class LogService {
         } catch (Throwable e) {
             runContext.logger().info(line.trim());
         }
+    }
+
+    /**
+     * Fusion v2.0 may emit numeric or uppercase level strings; normalize to lowercase dbt-classic values.
+     */
+    private static String normalizeLevel(String level) {
+        if (level == null) {
+            return null;
+        }
+        return switch (level.toLowerCase()) {
+            case "warning" -> "warn";
+            case "error", "critical" -> "error";
+            case "debug", "trace" -> "debug";
+            default -> level.toLowerCase();
+        };
     }
 }

--- a/src/main/java/io/kestra/plugin/dbt/models/Manifest.java
+++ b/src/main/java/io/kestra/plugin/dbt/models/Manifest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.dbt.models;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Value;
@@ -12,6 +13,7 @@ import lombok.extern.jackson.Jacksonized;
 @Value
 @Jacksonized
 @SuperBuilder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Manifest {
     Map<String, Object> metadata;
     Map<String, Node> nodes;
@@ -22,6 +24,7 @@ public class Manifest {
     @Value
     @Jacksonized
     @SuperBuilder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Node {
         @JsonProperty("compiled_sql")
         String compiledSql;

--- a/src/main/java/io/kestra/plugin/dbt/models/Manifest.java
+++ b/src/main/java/io/kestra/plugin/dbt/models/Manifest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.dbt.models;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Value;
@@ -12,6 +13,7 @@ import lombok.extern.jackson.Jacksonized;
 @Value
 @Jacksonized
 @SuperBuilder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Manifest {
     Map<String, Object> metadata;
     Map<String, Node> nodes;
@@ -25,6 +27,7 @@ public class Manifest {
     @Value
     @Jacksonized
     @SuperBuilder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Node {
         @JsonProperty("compiled_sql")
         String compiledSql;

--- a/src/main/java/io/kestra/plugin/dbt/models/RunResult.java
+++ b/src/main/java/io/kestra/plugin/dbt/models/RunResult.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kestra.core.models.flows.State;
@@ -15,6 +16,7 @@ import lombok.extern.jackson.Jacksonized;
 @Value
 @Jacksonized
 @SuperBuilder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RunResult {
     List<Result> results;
 
@@ -26,6 +28,7 @@ public class RunResult {
     @Value
     @Jacksonized
     @SuperBuilder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Result {
         String status;
 
@@ -48,27 +51,21 @@ public class RunResult {
         String uniqueId;
 
         public State.Type state() {
-            switch (this.status) {
-                case "error":
-                case "fail":
-                case "runtime_error":
-                    return State.Type.FAILED;
-                case "warn":
-                    return State.Type.WARNING;
-                case "skipped":
-                    return State.Type.SKIPPED;
-                case "success":
-                case "pass":
-                    return State.Type.SUCCESS;
-            }
-
-            throw new IllegalStateException("No suitable status for '" + this.status + "'");
+            return switch (this.status) {
+                case "error", "fail", "runtime_error" -> State.Type.FAILED;
+                case "warn" -> State.Type.WARNING;
+                case "skipped" -> State.Type.SKIPPED;
+                // Fusion v2.0 emits "run" for a successfully executed model
+                case "success", "pass", "run" -> State.Type.SUCCESS;
+                default -> throw new IllegalStateException("No suitable status for '" + this.status + "'");
+            };
         }
     }
 
     @Value
     @Jacksonized
     @SuperBuilder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Timing {
         String name;
 

--- a/src/main/java/io/kestra/plugin/dbt/models/RunResult.java
+++ b/src/main/java/io/kestra/plugin/dbt/models/RunResult.java
@@ -51,6 +51,7 @@ public class RunResult {
         String uniqueId;
 
         public State.Type state() {
+            if (this.status == null) return State.Type.FAILED;
             return switch (this.status) {
                 case "error", "fail", "runtime_error" -> State.Type.FAILED;
                 case "warn" -> State.Type.WARNING;

--- a/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
@@ -257,6 +257,80 @@ class ResultParserTest {
             .orElse(null);
     }
 
+    @Test
+    void parseRunResult_withFusionRunStatus_shouldSucceed() throws Exception {
+        var runContext = mockRunContext();
+        var runResultsFile = runContext.workingDir().path(true).resolve("run_results.json");
+        // Fusion v2.0 emits "run" as the status for a successfully executed model
+        Files.writeString(runResultsFile, """
+            {
+              "metadata": {
+                "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v6/run-results.json",
+                "dbt_version": "2.0.0"
+              },
+              "results": [
+                {
+                  "status": "run",
+                  "unique_id": "model.my_project.my_model",
+                  "timing": [
+                    {
+                      "name": "compile",
+                      "started_at": "2024-01-01T00:00:00.000000Z",
+                      "completed_at": "2024-01-01T00:00:01.000000Z"
+                    },
+                    {
+                      "name": "execute",
+                      "started_at": "2024-01-01T00:00:01.000000Z",
+                      "completed_at": "2024-01-01T00:00:02.000000Z"
+                    }
+                  ],
+                  "thread_id": "Thread-1",
+                  "execution_time": 2.0,
+                  "adapter_response": {},
+                  "message": "OK",
+                  "failures": null
+                }
+              ],
+              "elapsed_time": 2.5
+            }
+            """);
+
+        var uri = ResultParser.parseRunResult(runContext, runResultsFile.toFile(), null);
+
+        assertThat(uri, is(notNullValue()));
+    }
+
+    @Test
+    void parseRunResult_withUnknownTopLevelFields_shouldNotFail() throws Exception {
+        var runContext = mockRunContext();
+        var runResultsFile = runContext.workingDir().path(true).resolve("run_results.json");
+        // Fusion may add unknown top-level fields; @JsonIgnoreProperties ensures stability
+        Files.writeString(runResultsFile, """
+            {
+              "metadata": {},
+              "results": [
+                {
+                  "status": "success",
+                  "unique_id": "model.my_project.stg_orders",
+                  "timing": [],
+                  "thread_id": "Thread-1",
+                  "execution_time": 1.0,
+                  "adapter_response": {},
+                  "message": null,
+                  "failures": null,
+                  "fusion_extra_field": "ignored"
+                }
+              ],
+              "elapsed_time": 1.0,
+              "fusion_run_id": "some-uuid-from-fusion"
+            }
+            """);
+
+        var uri = ResultParser.parseRunResult(runContext, runResultsFile.toFile(), null);
+
+        assertThat(uri, is(notNullValue()));
+    }
+
     private RunContext mockRunContext() {
         var task = DbtCLI.builder()
             .id(IdUtils.create())

--- a/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
@@ -587,6 +587,96 @@ class ResultParserTest {
             .orElse(null);
     }
 
+    private static AssetEmit findEmitWithInput(List<AssetEmit> emitted, String inputId) {
+        return emitted.stream()
+            .filter(e -> e.inputs().stream().anyMatch(i -> i.id().equals(inputId)))
+            .filter(e -> e.outputs().isEmpty())
+            .findFirst()
+            .orElse(null);
+    }
+
+    private static AssetEmit findEmitWithInputAndOutput(List<AssetEmit> emitted, String inputId, String outputId) {
+        return emitted.stream()
+            .filter(e -> e.inputs().stream().anyMatch(i -> i.id().equals(inputId)))
+            .filter(e -> e.outputs().stream().anyMatch(o -> o.getId().equals(outputId)))
+            .findFirst()
+            .orElse(null);
+    }
+
+    @Test
+    void parseRunResult_withFusionRunStatus_shouldSucceed() throws Exception {
+        var runContext = mockRunContext();
+        var runResultsFile = runContext.workingDir().path(true).resolve("run_results.json");
+        // Fusion v2.0 emits "run" as the status for a successfully executed model
+        Files.writeString(runResultsFile, """
+            {
+              "metadata": {
+                "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v6/run-results.json",
+                "dbt_version": "2.0.0"
+              },
+              "results": [
+                {
+                  "status": "run",
+                  "unique_id": "model.my_project.my_model",
+                  "timing": [
+                    {
+                      "name": "compile",
+                      "started_at": "2024-01-01T00:00:00.000000Z",
+                      "completed_at": "2024-01-01T00:00:01.000000Z"
+                    },
+                    {
+                      "name": "execute",
+                      "started_at": "2024-01-01T00:00:01.000000Z",
+                      "completed_at": "2024-01-01T00:00:02.000000Z"
+                    }
+                  ],
+                  "thread_id": "Thread-1",
+                  "execution_time": 2.0,
+                  "adapter_response": {},
+                  "message": "OK",
+                  "failures": null
+                }
+              ],
+              "elapsed_time": 2.5
+            }
+            """);
+
+        var uri = ResultParser.parseRunResult(runContext, runResultsFile.toFile(), null);
+
+        assertThat(uri, is(notNullValue()));
+    }
+
+    @Test
+    void parseRunResult_withUnknownTopLevelFields_shouldNotFail() throws Exception {
+        var runContext = mockRunContext();
+        var runResultsFile = runContext.workingDir().path(true).resolve("run_results.json");
+        // Fusion may add unknown top-level fields; @JsonIgnoreProperties ensures stability
+        Files.writeString(runResultsFile, """
+            {
+              "metadata": {},
+              "results": [
+                {
+                  "status": "success",
+                  "unique_id": "model.my_project.stg_orders",
+                  "timing": [],
+                  "thread_id": "Thread-1",
+                  "execution_time": 1.0,
+                  "adapter_response": {},
+                  "message": null,
+                  "failures": null,
+                  "fusion_extra_field": "ignored"
+                }
+              ],
+              "elapsed_time": 1.0,
+              "fusion_run_id": "some-uuid-from-fusion"
+            }
+            """);
+
+        var uri = ResultParser.parseRunResult(runContext, runResultsFile.toFile(), null);
+
+        assertThat(uri, is(notNullValue()));
+    }
+
     private RunContext mockRunContext() {
         var task = DbtCLI.builder()
             .id(IdUtils.create())

--- a/src/test/java/io/kestra/plugin/dbt/cli/DbtCLITest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cli/DbtCLITest.java
@@ -283,7 +283,7 @@ class DbtCLITest {
                         "dbt deps",
                         "mkdir -p models",
                         "echo 'SELECT * FROM definitely_non_existent_table_12345' > models/failing_test_model.sql",
-                        "dbt run --models failing_test_model"
+                        "dbt run --select failing_test_model"
                     )
                 )
             )

--- a/src/test/java/io/kestra/plugin/dbt/cli/LogServiceTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cli/LogServiceTest.java
@@ -2,7 +2,6 @@ package io.kestra.plugin.dbt.cli;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/kestra/plugin/dbt/cli/LogServiceTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cli/LogServiceTest.java
@@ -1,0 +1,110 @@
+package io.kestra.plugin.dbt.cli;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.dbt.cli.DbtCLI;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest
+class LogServiceTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void parse_classicInfoFormat_shouldNotSetWarning() {
+        var runContext = mockRunContext();
+        var hasWarning = new AtomicBoolean(false);
+        // Classic dbt JSON log format with nested "info" block
+        var line = """
+            {"info":{"category":"","code":"Q011","invocation_id":"abc","level":"info","log_version":3,"msg":"Found 1 model","name":"MainReportArgs","pid":1,"thread":null,"ts":"2024-01-01T00:00:00Z"},"data":{}}
+            """.trim();
+
+        LogService.parse(runContext, line, hasWarning);
+
+        assertThat(hasWarning.get(), is(false));
+    }
+
+    @Test
+    void parse_classicWarnFormat_shouldSetWarning() {
+        var runContext = mockRunContext();
+        var hasWarning = new AtomicBoolean(false);
+        var line = """
+            {"info":{"category":"","code":"W001","invocation_id":"abc","level":"warn","log_version":3,"msg":"Deprecation warning","name":"DeprecatedModel","pid":1,"thread":null,"ts":"2024-01-01T00:00:00Z"},"data":{}}
+            """.trim();
+
+        LogService.parse(runContext, line, hasWarning);
+
+        assertThat(hasWarning.get(), is(true));
+    }
+
+    @Test
+    void parse_fusionFormat_shouldNotSetWarning() {
+        var runContext = mockRunContext();
+        var hasWarning = new AtomicBoolean(false);
+        // Fusion v2.0 JSON log format: flat with "message" key instead of nested "info"
+        var line = """
+            {"level":"info","ts":"2024-01-01T00:00:00Z","name":"MainReportArgs","message":"Found 2 models","thread_name":"MainThread","pid":42}
+            """.trim();
+
+        LogService.parse(runContext, line, hasWarning);
+
+        assertThat(hasWarning.get(), is(false));
+    }
+
+    @Test
+    void parse_fusionWarningLevel_shouldSetWarning() {
+        var runContext = mockRunContext();
+        var hasWarning = new AtomicBoolean(false);
+        // Fusion may emit "warning" (full word) instead of "warn"
+        var line = """
+            {"level":"warning","ts":"2024-01-01T00:00:00Z","name":"Deprecation","message":"This feature is deprecated","thread_name":"MainThread","pid":42}
+            """.trim();
+
+        LogService.parse(runContext, line, hasWarning);
+
+        assertThat(hasWarning.get(), is(true));
+    }
+
+    @Test
+    void parse_nonJsonLine_shouldNotThrow() {
+        var runContext = mockRunContext();
+        var hasWarning = new AtomicBoolean(false);
+
+        LogService.parse(runContext, "plain text output", hasWarning);
+
+        assertThat(hasWarning.get(), is(false));
+    }
+
+    @Test
+    void parse_nullLine_shouldNotThrow() {
+        var runContext = mockRunContext();
+        var hasWarning = new AtomicBoolean(false);
+
+        LogService.parse(runContext, null, hasWarning);
+
+        assertThat(hasWarning.get(), is(false));
+    }
+
+    private io.kestra.core.runners.RunContext mockRunContext() {
+        var task = DbtCLI.builder()
+            .id(IdUtils.create())
+            .type(DbtCLI.class.getName())
+            .commands(Property.ofValue(List.of("dbt run")))
+            .build();
+        return TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+    }
+}

--- a/src/test/java/io/kestra/plugin/dbt/cli/RunnerTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cli/RunnerTest.java
@@ -40,6 +40,12 @@ class RunnerTest {
     }
 
     @Test
+    @ExecuteFlow("sanity-checks/dbt_cli_fusion_test.yaml")
+    void fusionEngine(Execution execution) {
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+    }
+
+    @Test
     @ExecuteFlow("sanity-checks/dbt_cli_complex_dag_test.yaml")
     void complexDagLineage(Execution execution) {
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/src/test/java/io/kestra/plugin/dbt/models/RunResultTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/models/RunResultTest.java
@@ -1,6 +1,8 @@
 package io.kestra.plugin.dbt.models;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import io.kestra.core.models.flows.State;
 
@@ -15,5 +17,25 @@ class RunResultTest {
             .build();
 
         assertThat(result.state(), is(State.Type.SKIPPED));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "success, SUCCESS",
+        "pass, SUCCESS",
+        // Fusion v2.0 emits "run" for a successfully executed model
+        "run, SUCCESS",
+        "error, FAILED",
+        "fail, FAILED",
+        "runtime_error, FAILED",
+        "warn, WARNING",
+        "skipped, SKIPPED"
+    })
+    void state_allStatuses(String status, String expectedState) {
+        var result = RunResult.Result.builder()
+            .status(status)
+            .build();
+
+        assertThat(result.state(), is(State.Type.valueOf(expectedState)));
     }
 }

--- a/src/test/resources/sanity-checks/dbt_cli_assets_kv_test.yaml
+++ b/src/test/resources/sanity-checks/dbt_cli_assets_kv_test.yaml
@@ -64,7 +64,7 @@ tasks:
 
         commands:
           - dbt deps
-          - dbt build --no-partial-parse
+          - dbt build
 
         profiles: |
           my_dbt_project:
@@ -90,7 +90,7 @@ tasks:
 
         # (optional) shows it works with flags too; adapt as needed
         commands:
-          - dbt build --no-partial-parse
+          - dbt build
 
         profiles: |
           my_dbt_project:

--- a/src/test/resources/sanity-checks/dbt_cli_assets_kv_test.yaml
+++ b/src/test/resources/sanity-checks/dbt_cli_assets_kv_test.yaml
@@ -61,7 +61,7 @@ tasks:
 
         commands:
           - dbt deps
-          - dbt build --no-partial-parse
+          - dbt build
 
         profiles: |
           my_dbt_project:
@@ -87,7 +87,7 @@ tasks:
 
         # (optional) shows it works with flags too; adapt as needed
         commands:
-          - dbt build --no-partial-parse
+          - dbt build
 
         profiles: |
           my_dbt_project:

--- a/src/test/resources/sanity-checks/dbt_cli_fusion_test.yaml
+++ b/src/test/resources/sanity-checks/dbt_cli_fusion_test.yaml
@@ -1,0 +1,56 @@
+id: dbt_cli_fusion_test
+namespace: company.team
+
+tasks:
+  - id: wd
+    type: io.kestra.plugin.core.flow.WorkingDirectory
+    tasks:
+      - id: create_project
+        type: io.kestra.plugin.core.storage.LocalFiles
+        inputs:
+          dbt_project.yml: |
+            name: 'my_dbt_project'
+            version: '1.0.0'
+            config-version: 2
+
+            profile: 'my_dbt_project'
+
+            model-paths: ["models"]
+            analysis-paths: ["analyses"]
+            test-paths: ["tests"]
+            seed-paths: ["seeds"]
+            macro-paths: ["macros"]
+            snapshot-paths: ["snapshots"]
+
+            target-path: "target"
+            clean-targets:
+              - "target"
+              - "dbt_packages"
+
+            models:
+              my_dbt_project:
+                +materialized: table
+          packages.yml: |
+            packages: []
+          models/example.sql: |
+            select 1 as id
+          models/example_two.sql: |
+            select 2 as id
+
+      - id: dbt_fusion_build
+        type: io.kestra.plugin.dbt.cli.DbtCLI
+        engine: FUSION
+        taskRunner:
+          type: io.kestra.plugin.scripts.runner.docker.Docker
+          delete: true
+        commands:
+          - dbt deps
+          - dbt build
+        profiles: |
+          my_dbt_project:
+            outputs:
+              dev:
+                type: duckdb
+                path: ":memory:"
+                threads: 4
+            target: dev

--- a/src/test/resources/sanity-checks/dbt_cli_fusion_test.yaml
+++ b/src/test/resources/sanity-checks/dbt_cli_fusion_test.yaml
@@ -4,39 +4,37 @@ namespace: company.team
 tasks:
   - id: wd
     type: io.kestra.plugin.core.flow.WorkingDirectory
+    inputFiles:
+      dbt_project.yml: |
+        name: 'my_dbt_project'
+        version: '1.0.0'
+        config-version: 2
+
+        profile: 'my_dbt_project'
+
+        model-paths: ["models"]
+        analysis-paths: ["analyses"]
+        test-paths: ["tests"]
+        seed-paths: ["seeds"]
+        macro-paths: ["macros"]
+        snapshot-paths: ["snapshots"]
+
+        target-path: "target"
+        clean-targets:
+          - "target"
+          - "dbt_packages"
+
+        models:
+          my_dbt_project:
+            +materialized: table
+      packages.yml: |
+        packages: []
+      models/example.sql: |
+        select 1 as id
+      models/example_two.sql: |
+        select 2 as id
+
     tasks:
-      - id: create_project
-        type: io.kestra.plugin.core.storage.LocalFiles
-        inputs:
-          dbt_project.yml: |
-            name: 'my_dbt_project'
-            version: '1.0.0'
-            config-version: 2
-
-            profile: 'my_dbt_project'
-
-            model-paths: ["models"]
-            analysis-paths: ["analyses"]
-            test-paths: ["tests"]
-            seed-paths: ["seeds"]
-            macro-paths: ["macros"]
-            snapshot-paths: ["snapshots"]
-
-            target-path: "target"
-            clean-targets:
-              - "target"
-              - "dbt_packages"
-
-            models:
-              my_dbt_project:
-                +materialized: table
-          packages.yml: |
-            packages: []
-          models/example.sql: |
-            select 1 as id
-          models/example_two.sql: |
-            select 2 as id
-
       - id: dbt_fusion_build
         type: io.kestra.plugin.dbt.cli.DbtCLI
         engine: FUSION
@@ -52,5 +50,6 @@ tasks:
               dev:
                 type: duckdb
                 path: ":memory:"
+                database: memory
                 threads: 4
             target: dev


### PR DESCRIPTION
:warning: Let's wait 2.0.0 GA before to merge this one.

## Summary

- Fix `AbstractRun.java:77` selector bug: `this.target` was rendered instead of `this.selector` in the `--selector` branch
- Replace deprecated `--models` flag with `--select` in `DbtCLITest` failure scenario
- Add a full Fusion example to `DbtCLI` `@Plugin(examples = ...)` and update engine `@Schema` to note that `--no-partial-parse` / `--partial-parse` are silently ignored by Fusion
- Remove `--no-partial-parse` from `dbt_cli_assets_kv_test.yaml` sanity check
- Add `@JsonIgnoreProperties(ignoreUnknown = true)` to `RunResult` and `Manifest` models to prevent crashes when Fusion v2.0 adds new fields
- Map Fusion's `"run"` result status to `State.Type.SUCCESS` in `RunResult.state()`
- Update `LogService` to handle Fusion v2.0's flat `"message"` log format alongside classic nested `"info"` format; normalize `"warning"` → `"warn"`, `"trace"` → `"debug"`, etc.
- Guard `LogService.parse()` against null line input
- Add `dbt_cli_fusion_test.yaml` sanity-check flow + `RunnerTest.fusionEngine()` test method
- New `LogServiceTest` covering both classic and Fusion log formats
- New `ResultParser` tests for Fusion `run_results.json` (unknown fields + `"run"` status)
- Parameterized `RunResultTest` covering all status values including `"run"`
- Document the `selector` bug fix with a `@Schema(description)` note on the property

closes: https://github.com/kestra-io/plugin-dbt/issues/272

## dbt Core v2.0 GA — next steps

dbt Core v2.0 (Fusion engine) is still in alpha at the time this PR is merged. The plugin code is fully ready for v2.0, but the `ghcr.io/kestra-io/dbt-fusion` image must be updated once v2.0 reaches GA.

### When dbt Core v2.0 goes GA

1. Open a PR that touches `dockerfiles/dbt-fusion.Dockerfile` (e.g. update a comment) and merge it to `main` — the `push: paths: dockerfiles/*` trigger in [`packages.yml`](../../actions/workflows/packages.yml) will rebuild and push `ghcr.io/kestra-io/dbt-fusion:latest` pointing to v2.0.
2. Run [`packages.yml`](../../actions/workflows/packages.yml) via `workflow_dispatch` with `dbt_version: 2.0.0` to push the pinned `ghcr.io/kestra-io/dbt-fusion:dbt-2.0.0` tag. Users who want to pin explicitly can then set `containerImage: ghcr.io/kestra-io/dbt-fusion:dbt-2.0.0` on their task.
3. No plugin code changes are needed: the compatibility work in this PR already handles v2.0 log format, result status values, and schema additions.

> **Note:** step 1 (Dockerfile change on `main`) is a prerequisite for step 2 to work — the `changes` job in `packages.yml` gates the build on detected Dockerfile modifications via `dorny/paths-filter`, so `workflow_dispatch` alone will not trigger a build.

## Test plan

- [x] `./gradlew test` passes (44 tests, 0 failures)
- [x] `./gradlew shadowJar` builds
- [x] Existing `Engine.CORE` tests unchanged (skipped due to missing BigQuery credentials)
- [x] `RunnerTest.fusionEngine()` sanity-check flow passes with dbt-fusion Docker image
- [x] `LogServiceTest` validates both classic and Fusion log formats
- [x] `RunResultTest.state_allStatuses` covers all statuses including Fusion's `"run"`