### PR TITLE
fix(cloud): prevent inverted job status in CheckStatus (#271)

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -27,6 +27,7 @@ import io.kestra.plugin.dbt.ResultParser;
 import io.kestra.plugin.dbt.cloud.models.JobStatus;
 import io.kestra.plugin.dbt.cloud.models.JobStatusHumanizedEnum;
 import io.kestra.plugin.dbt.cloud.models.ManifestArtifact;
+import io.kestra.plugin.dbt.cloud.models.Run;
 import io.kestra.plugin.dbt.cloud.models.RunResponse;
 import io.kestra.plugin.dbt.cloud.models.Step;
 import io.kestra.plugin.dbt.models.RunResult;
@@ -131,27 +132,18 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
                 if (fetchRunResponse.isPresent()) {
                     logSteps(logger, fetchRunResponse.get());
 
+                    var data = fetchRunResponse.get().getData();
+
                     // we rely on truncated logs to be sure
-                    boolean allLogs = fetchRunResponse.get()
-                        .getData()
-                        .getRunSteps()
+                    boolean allLogs = data.getRunSteps()
                         .stream()
                         .filter(step -> step.getTruncatedDebugLogs() != null)
-                        .count() == fetchRunResponse.get()
-                            .getData()
-                            .getRunSteps().size();
+                        .count() == data.getRunSteps().size();
 
-                    var runStatus = fetchRunResponse.get().getData().getStatus();
-                    if (runStatus == null) {
-                        logger.warn("Received null status from dbt Cloud — skipping this poll cycle");
-                    } else if (ENDED_STATUS.contains(runStatus) && allLogs) {
+                    if (data.getStatus() == null && data.getIsComplete() == null && data.getStatusHumanized() == null) {
+                        logger.warn("Received response with no status indicator from dbt Cloud — skipping this poll cycle");
+                    } else if (isEnded(data) && allLogs) {
                         return fetchRunResponse.get();
-                    } else if (!ENDED_STATUS.contains(runStatus)
-                            && runStatus != JobStatus.NUMBER_1
-                            && runStatus != JobStatus.NUMBER_2
-                            && runStatus != JobStatus.NUMBER_3) {
-                        // Unrecognized code: log and continue polling rather than stalling silently.
-                        logger.warn("Unrecognized dbt Cloud status {} — continuing to poll", runStatus);
                     }
                 }
 
@@ -164,7 +156,7 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
         // final response
         logSteps(logger, finalRunResponse);
 
-        if (finalRunResponse.getData().getStatus() != JobStatus.NUMBER_10) {
+        if (!isSuccessful(finalRunResponse.getData())) {
             throw new Exception(
                 "Failed run with status '" + finalRunResponse.getData().getStatusHumanized() +
                     "' after " + finalRunResponse.getData().getDurationHumanized() +
@@ -203,6 +195,33 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
             .runResults(runResultsUri)
             .manifest(manifestUri)
             .build();
+    }
+
+    // Precedence: integer status → is_complete → status_humanized
+    private boolean isEnded(Run data) {
+        if (data.getStatus() != null) {
+            return ENDED_STATUS.contains(data.getStatus());
+        }
+        if (data.getIsComplete() != null) {
+            return Boolean.TRUE.equals(data.getIsComplete());
+        }
+        if (data.getStatusHumanized() != null) {
+            return data.getStatusHumanized() == JobStatusHumanizedEnum.SUCCESS
+                || data.getStatusHumanized() == JobStatusHumanizedEnum.ERROR
+                || data.getStatusHumanized() == JobStatusHumanizedEnum.CANCELLED;
+        }
+        return false;
+    }
+
+    // Precedence: integer status → is_success/is_error → status_humanized
+    private boolean isSuccessful(Run data) {
+        if (data.getStatus() != null) {
+            return data.getStatus() == JobStatus.NUMBER_10;
+        }
+        if (data.getIsSuccess() != null) {
+            return Boolean.TRUE.equals(data.getIsSuccess()) && !Boolean.TRUE.equals(data.getIsError());
+        }
+        return JobStatusHumanizedEnum.SUCCESS.equals(data.getStatusHumanized());
     }
 
     private void logSteps(Logger logger, RunResponse runResponse) {

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.http.client.HttpClientException;
+import io.kestra.core.http.client.HttpClientResponseException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.property.Property;
@@ -23,6 +24,7 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.Await;
 import io.kestra.plugin.dbt.ResultParser;
+import io.kestra.plugin.dbt.cloud.models.JobStatus;
 import io.kestra.plugin.dbt.cloud.models.JobStatusHumanizedEnum;
 import io.kestra.plugin.dbt.cloud.models.ManifestArtifact;
 import io.kestra.plugin.dbt.cloud.models.RunResponse;
@@ -66,10 +68,10 @@ import io.kestra.core.models.annotations.PluginProperty;
     }
 )
 public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckStatus.Output> {
-    private static final List<JobStatusHumanizedEnum> ENDED_STATUS = List.of(
-        JobStatusHumanizedEnum.ERROR,
-        JobStatusHumanizedEnum.CANCELLED,
-        JobStatusHumanizedEnum.SUCCESS
+    private static final Set<JobStatus> ENDED_STATUS = Set.of(
+        JobStatus.NUMBER_10,  // Success
+        JobStatus.NUMBER_20,  // Error
+        JobStatus.NUMBER_30   // Cancelled
     );
 
     @Schema(
@@ -139,9 +141,17 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
                             .getData()
                             .getRunSteps().size();
 
-                    // ended
-                    if (ENDED_STATUS.contains(fetchRunResponse.get().getData().getStatusHumanized()) && allLogs) {
+                    var runStatus = fetchRunResponse.get().getData().getStatus();
+                    if (runStatus == null) {
+                        logger.warn("Received null status from dbt Cloud — skipping this poll cycle");
+                    } else if (ENDED_STATUS.contains(runStatus) && allLogs) {
                         return fetchRunResponse.get();
+                    } else if (!ENDED_STATUS.contains(runStatus)
+                            && runStatus != JobStatus.NUMBER_1
+                            && runStatus != JobStatus.NUMBER_2
+                            && runStatus != JobStatus.NUMBER_3) {
+                        // Unrecognized code: log and continue polling rather than stalling silently.
+                        logger.warn("Unrecognized dbt Cloud status {} — continuing to poll", runStatus);
                     }
                 }
 
@@ -154,19 +164,26 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
         // final response
         logSteps(logger, finalRunResponse);
 
-        if (!finalRunResponse.getData().getStatusHumanized().equals(JobStatusHumanizedEnum.SUCCESS)) {
+        if (finalRunResponse.getData().getStatus() != JobStatus.NUMBER_10) {
             throw new Exception(
                 "Failed run with status '" + finalRunResponse.getData().getStatusHumanized() +
-                    "' after " + finalRunResponse.getData().getDurationHumanized() + ": " + finalRunResponse
+                    "' after " + finalRunResponse.getData().getDurationHumanized() +
+                    (finalRunResponse.getData().getStatusMessage() != null
+                        ? ": " + finalRunResponse.getData().getStatusMessage()
+                        : "") +
+                    ": " + finalRunResponse
             );
         }
 
+        // Artifacts are uploaded asynchronously by dbt Cloud and manifest.json is absent for some
+        // run shapes (e.g. dbt source freshness). Tolerate 404 so a legitimate success is not
+        // reported as a failure.
         Path runResultsArtifact = downloadArtifacts(runContext, runIdRendered, "run_results.json", RunResult.class);
         Path manifestArtifact = downloadArtifacts(runContext, runIdRendered, "manifest.json", ManifestArtifact.class);
 
         io.kestra.plugin.dbt.models.Manifest manifest = null;
         URI manifestUri = null;
-        if (manifestArtifact.toFile().exists()) {
+        if (manifestArtifact != null) {
             ResultParser.ManifestResult manifestResult = ResultParser.parseManifestWithAssets(runContext, manifestArtifact.toFile());
             manifest = manifestResult.manifest();
             manifestUri = manifestResult.uri();
@@ -174,10 +191,10 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
 
         URI runResultsUri = null;
 
-        if (runContext.render(this.parseRunResults).as(Boolean.class).orElse(false)) {
-            runResultsUri = ResultParser.parseRunResult(runContext, runResultsArtifact.toFile(), manifest);
-        } else {
-            if (Files.exists(runResultsArtifact)) {
+        if (runResultsArtifact != null) {
+            if (runContext.render(this.parseRunResults).as(Boolean.class).orElse(false)) {
+                runResultsUri = ResultParser.parseRunResult(runContext, runResultsArtifact.toFile(), manifest);
+            } else {
                 runResultsUri = runContext.storage().putFile(runResultsArtifact.toFile());
             }
         }
@@ -229,9 +246,16 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
         return Optional.ofNullable(this.request(runContext, requestBuilder, RunResponse.class).getBody());
     }
 
+    /**
+     * Downloads an artifact and writes it to a temp file. Returns null when the artifact is not
+     * found (404), which is a legitimate outcome for async uploads or run shapes that don't
+     * produce every artifact (e.g. manifest.json is absent for dbt source freshness runs).
+     * 5xx errors are still retried by {@link AbstractDbtCloud#request}; other unexpected errors
+     * still propagate.
+     */
     private <T> Path downloadArtifacts(RunContext runContext, Long runId, String path, Class<T> responseType)
         throws IllegalVariableEvaluationException, IOException, HttpClientException {
-        HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
+        var requestBuilder = HttpRequest.builder()
             .uri(
                 URI.create(
                     runContext.render(this.baseUrl).as(String.class).orElseThrow()
@@ -241,13 +265,20 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
             )
             .method("GET");
 
-        T artifact = this.request(runContext, requestBuilder, responseType).getBody();
+        T artifact;
+        try {
+            artifact = this.request(runContext, requestBuilder, responseType).getBody();
+        } catch (HttpClientResponseException ex) {
+            if (ex.getResponse().getStatus().getCode() == 404) {
+                runContext.logger().debug("Artifact '{}' not found (404) — skipping", path);
+                return null;
+            }
+            throw ex;
+        }
 
-        String artifactJson = JacksonMapper.ofJson().writeValueAsString(artifact);
-
-        Path tempFile = runContext.workingDir().createTempFile(".json");
+        var artifactJson = JacksonMapper.ofJson().writeValueAsString(artifact);
+        var tempFile = runContext.workingDir().createTempFile(".json");
         Files.writeString(tempFile, artifactJson, StandardOpenOption.TRUNCATE_EXISTING);
-
         return tempFile;
     }
 

--- a/src/main/java/io/kestra/plugin/dbt/cloud/models/Run.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/models/Run.java
@@ -144,4 +144,16 @@ public class Run {
 
     @JsonProperty("created_at_humanized")
     String createdAtHumanized;
+
+    @JsonProperty("is_complete")
+    Boolean isComplete;
+
+    @JsonProperty("is_success")
+    Boolean isSuccess;
+
+    @JsonProperty("is_error")
+    Boolean isError;
+
+    @JsonProperty("is_cancelled")
+    Boolean isCancelled;
 }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
@@ -17,8 +17,11 @@ import jakarta.inject.Inject;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
 @WireMockTest(httpPort = 8089)
@@ -42,6 +45,7 @@ class CheckStatusTest {
                         {
                           "data": {
                             "id": 9999,
+                            "status": 10,
                             "status_humanized": "Success",
                             "duration_humanized": "0s",
                             "run_steps": []
@@ -77,5 +81,201 @@ class CheckStatusTest {
 
         assertThat(checkStatusOutput, is(notNullValue()));
         assertThat(checkStatusOutput.getRunResults(), is(notNullValue()));
+    }
+
+    /**
+     * Regression test for defect 1: manifest.json returning 404 must not fail an otherwise
+     * successful run.
+     */
+    @Test
+    void shouldSucceedWhenManifestArtifactMissing() throws Exception {
+        stubFor(
+            get(urlMatching("/api/v2/accounts/123/runs/7777/\\?.*"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 7777,
+                            "status": 10,
+                            "status_humanized": "Success",
+                            "duration_humanized": "1s",
+                            "run_steps": []
+                          }
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/7777/artifacts/run_results.json"))
+                .willReturn(okJson("""
+                        {
+                          "metadata": {},
+                          "results": [],
+                          "elapsed_time": 0.0
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/7777/artifacts/manifest.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        CheckStatus checkStatus = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .baseUrl(Property.ofValue("http://localhost:8089"))
+            .runId(Property.ofValue("7777"))
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .parseRunResults(Property.ofValue(false))
+            .build();
+
+        CheckStatus.Output output = checkStatus.run(runContext);
+
+        assertThat(output, is(notNullValue()));
+        // run_results was present — URI must be set
+        assertThat(output.getRunResults(), is(notNullValue()));
+        // manifest was 404 — URI must be absent
+        assertThat(output.getManifest(), is(nullValue()));
+    }
+
+    /**
+     * Both artifacts return 404 (e.g. brief async upload delay). The task must still succeed.
+     */
+    @Test
+    void shouldSucceedWhenBothArtifacts404() throws Exception {
+        stubFor(
+            get(urlMatching("/api/v2/accounts/123/runs/8888/\\?.*"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 8888,
+                            "status": 10,
+                            "status_humanized": "Success",
+                            "duration_humanized": "1s",
+                            "run_steps": []
+                          }
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/8888/artifacts/run_results.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/8888/artifacts/manifest.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        CheckStatus checkStatus = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .baseUrl(Property.ofValue("http://localhost:8089"))
+            .runId(Property.ofValue("8888"))
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .parseRunResults(Property.ofValue(false))
+            .build();
+
+        CheckStatus.Output output = checkStatus.run(runContext);
+
+        assertThat(output, is(notNullValue()));
+        assertThat(output.getRunResults(), is(nullValue()));
+        assertThat(output.getManifest(), is(nullValue()));
+    }
+
+    /**
+     * A run with integer status 20 (Error) must throw and include status_message in the message.
+     * Regression test for defect 2: the verdict must use the authoritative integer status field.
+     */
+    @Test
+    void shouldFailOnErrorStatus() throws Exception {
+        stubFor(
+            get(urlMatching("/api/v2/accounts/123/runs/6666/\\?.*"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 6666,
+                            "status": 20,
+                            "status_humanized": "Error",
+                            "status_message": "Compilation failed in step 1",
+                            "duration_humanized": "2s",
+                            "run_steps": []
+                          }
+                        }
+                    """))
+        );
+
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        CheckStatus checkStatus = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .baseUrl(Property.ofValue("http://localhost:8089"))
+            .runId(Property.ofValue("6666"))
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .build();
+
+        var ex = assertThrows(Exception.class, () -> checkStatus.run(runContext));
+        assertThat(ex.getMessage(), containsString("Compilation failed in step 1"));
+    }
+
+    /**
+     * The latch and verdict must use the integer status field even when status_humanized carries an
+     * unrecognized string. Integer 10 = Success regardless of the display label.
+     */
+    @Test
+    void shouldSucceedWhenStatusHumanizedIsUnrecognized() throws Exception {
+        stubFor(
+            get(urlMatching("/api/v2/accounts/123/runs/5555/\\?.*"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 5555,
+                            "status": 10,
+                            "status_humanized": "Completed",
+                            "duration_humanized": "3s",
+                            "run_steps": []
+                          }
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/5555/artifacts/run_results.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/5555/artifacts/manifest.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        CheckStatus checkStatus = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .baseUrl(Property.ofValue("http://localhost:8089"))
+            .runId(Property.ofValue("5555"))
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .parseRunResults(Property.ofValue(false))
+            .build();
+
+        // Must not throw — integer status 10 is authoritative regardless of humanized label.
+        CheckStatus.Output output = checkStatus.run(runContext);
+        assertThat(output, is(notNullValue()));
     }
 }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
@@ -231,6 +231,54 @@ class CheckStatusTest {
     }
 
     /**
+     * Regression lock: a response carrying only status_humanized (no integer status field) must
+     * still resolve the latch and succeed. This matches the stub shape used by testTriggerRunWithWait.
+     */
+    @Test
+    void shouldSucceedWhenOnlyStatusHumanizedPresent() throws Exception {
+        stubFor(
+            get(urlMatching("/api/v2/accounts/123/runs/4444/\\?.*"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 4444,
+                            "status_humanized": "Success",
+                            "duration_humanized": "1s",
+                            "run_steps": []
+                          }
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/4444/artifacts/run_results.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/4444/artifacts/manifest.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        CheckStatus checkStatus = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .baseUrl(Property.ofValue("http://localhost:8089"))
+            .runId(Property.ofValue("4444"))
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .parseRunResults(Property.ofValue(false))
+            .build();
+
+        CheckStatus.Output output = checkStatus.run(runContext);
+
+        assertThat(output, is(notNullValue()));
+    }
+
+    /**
      * The latch and verdict must use the integer status field even when status_humanized carries an
      * unrecognized string. Integer 10 = Success regardless of the display label.
      */


### PR DESCRIPTION
## What

Should Fixes #271 (didn't manage to reproduce) — the dbt Cloud connector intermittently reporting an inverted job status (a successful run shown as failed, occasionally the reverse).

## Root cause

Two distinct defects in `CheckStatus.java`, both found by code analysis (the bug is timing/config dependent, so it never reproduced under live triggering — we only ever sampled the API after the race window had closed):

1. **Successful run → reported as failure (primary, intermittent).** After the success verdict, `run_results.json` and `manifest.json` were downloaded unconditionally, and `request()` retries only 502/503/504 — **not 404**. dbt Cloud uploads artifacts asynchronously (brief post-completion 404), and `manifest.json` legitimately doesn't exist for some run shapes (e.g. `dbt source freshness`). Either case threw → a genuinely successful run reported as failed. The pre-existing `manifestArtifact.toFile().exists()` guard proved the author *intended* the manifest to be optional, but the throw made it unreachable.
2. **Verdict on a display string.** The latch and the success/failure decision relied solely on `status_humanized` via `JobStatusHumanizedEnum.fromValue()`. An unrecognized string → `null` → never latches → 60-minute timeout → failure on a successful run. The authoritative machine fields (integer `status`, `is_complete`/`is_success`/`is_error`) were ignored.

## Changes

- **Artifact 404 tolerance:** `downloadArtifacts` returns `null` on a 404 (DEBUG-logged); all other codes re-throw (5xx still retried). Callers guard with null checks, restoring the intended optional-artifact behavior.
- **Authoritative, backward-compatible verdict:** new `isEnded()` / `isSuccessful()` helpers with precedence **integer `status` → `is_complete`/`is_success`+`is_error` flags → `status_humanized`**. Real responses (always carry integer status) get the inversion-proof path; responses carrying only `status_humanized` still work (no regression). `status_message` is now included in the failure exception.
- **Model:** map `is_complete`/`is_success`/`is_error`/`is_cancelled` on `Run`.

## Backward compatibility

No input or output schema changes. Both API response shapes the codebase ever accepted (integer-status and humanized-only) work. The only behavioral change for existing flows is the intended fix: a successful run with a missing/late artifact no longer fails (its output URI may be `null` instead).

## Tests

WireMock regression tests, all passing (`CheckStatusTest`, `CheckStatusRetryTest`, `MockTriggerRunTest`):
- `shouldSucceedWhenManifestArtifactMissing`, `shouldSucceedWhenBothArtifacts404` — artifact 404 tolerance
- `shouldFailOnErrorStatus` — integer status 20 throws, message includes `status_message`
- `shouldSucceedWhenStatusHumanizedIsUnrecognized` — integer status is authoritative over an unknown humanized label
- `shouldSucceedWhenOnlyStatusHumanizedPresent` — humanized-only fallback (backward-compat lock)
- `MockTriggerRunTest.testTriggerRunWithWait` passes **unmodified**

🤖 Generated with [Claude Code](https://claude.com/claude-code)