### PR TITLE
feat: show dbt model logs under their dynamic taskruns

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=1.6.4-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.26
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g

--- a/src/main/java/io/kestra/plugin/dbt/ResultParser.java
+++ b/src/main/java/io/kestra/plugin/dbt/ResultParser.java
@@ -20,6 +20,7 @@ import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AssetEmit;
+import io.kestra.core.runners.DynamicTaskRunLog;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.serializers.JacksonMapper;
@@ -27,7 +28,9 @@ import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.dbt.models.Manifest;
 import io.kestra.plugin.dbt.models.RunResult;
 
-import static io.kestra.core.utils.Rethrow.throwFunction;
+import org.slf4j.event.Level;
+
+import static io.kestra.core.utils.Rethrow.throwConsumer;
 
 public abstract class ResultParser {
     static final protected ObjectMapper MAPPER = JacksonMapper.ofJson(false)
@@ -53,10 +56,13 @@ public abstract class ResultParser {
 
         Map<String, ModelAsset> modelAssets = manifest == null ? Map.of() : extractModelAssets(manifest);
 
-        java.util.List<WorkerTaskResult> workerTaskResults = result
+        // Emit one dynamic taskrun per dbt model (the UI timeline "bars"), attaching that model's
+        // own status/message/failures as logs riding with its taskrun so they render inline under
+        // its bar instead of all landing on the parent task root (issue #276).
+        result
             .getResults()
             .stream()
-            .map(throwFunction(r ->
+            .forEach(throwConsumer(r ->
             {
                 ArrayList<State.History> histories = new ArrayList<>();
 
@@ -129,7 +135,6 @@ public abstract class ResultParser {
                     .namespace(runContext.render("{{ flow.namespace }}"))
                     .flowId(runContext.render("{{ flow.id }}"))
                     .taskId(r.getUniqueId())
-                    .value(runContext.render("{{ taskrun.id }}"))
                     .executionId(runContext.render("{{ execution.id }}"))
                     .parentTaskRunId(runContext.render("{{ taskrun.id }}"))
                     .state(state)
@@ -144,15 +149,47 @@ public abstract class ResultParser {
                     taskRunBuilder.assets(assets);
                 }
 
-                return WorkerTaskResult.builder()
-                    .taskRun(taskRunBuilder.build())
-                    .build();
-            }))
-            .toList();
-
-        runContext.dynamicWorkerResult(workerTaskResults);
+                // Register the dynamic taskrun together with its log lines in one call: the run
+                // context builds the LogEntry, forcing execution/tenant/namespace/flow from itself,
+                // fixing the attempt to 0 and masking secrets (the plugin never builds a LogEntry).
+                runContext.dynamicWorkerResult(
+                    WorkerTaskResult.builder().taskRun(taskRunBuilder.build()).build(),
+                    modelLogs(r)
+                );
+            }));
 
         return runContext.storage().putFile(file);
+    }
+
+    /**
+     * Build the log lines for a single dbt model, to be attached to that model's dynamic taskrun.
+     * A concise summary line (`uniqueId => status`, execution time, and the failure count when any),
+     * followed by the model's own message when present (SQL/compile errors, dbt status messages).
+     * rows_affected / bytes_processed are intentionally left out — they are already emitted as metrics.
+     */
+    static List<DynamicTaskRunLog> modelLogs(RunResult.Result r) {
+        Level level = switch (r.state()) {
+            case FAILED -> Level.ERROR;
+            case WARNING -> Level.WARN;
+            default -> Level.INFO;
+        };
+
+        List<DynamicTaskRunLog> logs = new ArrayList<>();
+
+        StringBuilder summary = new StringBuilder(r.getUniqueId() + " => " + r.getStatus());
+        if (r.getExecutionTime() != null) {
+            summary.append(String.format(Locale.ROOT, " in %.2fs", r.getExecutionTime()));
+        }
+        if (r.getFailures() != null && r.getFailures() > 0) {
+            summary.append(" (").append(r.getFailures()).append(r.getFailures() == 1 ? " failure)" : " failures)");
+        }
+        logs.add(new DynamicTaskRunLog(level, summary.toString()));
+
+        if (r.getMessage() != null && !r.getMessage().isBlank()) {
+            logs.add(new DynamicTaskRunLog(level, r.getMessage()));
+        }
+
+        return logs;
     }
 
     private static AssetsInOut assetsFor(String uniqueId, Map<String, ModelAsset> modelAssets) {

--- a/src/test/java/io/kestra/plugin/dbt/ResultParserModelLogsTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/ResultParserModelLogsTest.java
@@ -1,0 +1,114 @@
+package io.kestra.plugin.dbt;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
+
+import io.kestra.core.runners.DynamicTaskRunLog;
+import io.kestra.plugin.dbt.models.RunResult;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Pure unit test for the per-model log lines built from {@code run_results.json}. Runs without a
+ * Micronaut context — the routing of these lines to each model's dynamic taskrun (taskRunId, fixed
+ * attempt 0) is core's responsibility and is asserted in {@code ResultParserTest}.
+ */
+class ResultParserModelLogsTest {
+    @Test
+    void modelLogs_success_summaryAndMessage() {
+        var result = RunResult.Result.builder()
+            .status("success")
+            .message("CREATE VIEW")
+            .uniqueId("model.my_project.stg_orders")
+            .executionTime(0.42)
+            .build();
+
+        List<DynamicTaskRunLog> logs = ResultParser.modelLogs(result);
+
+        assertThat(logs, hasSize(2));
+        assertThat(logs.getFirst().level(), is(Level.INFO));
+        assertThat(logs.getFirst().message(), allOf(
+            containsString("model.my_project.stg_orders"),
+            containsString("success"),
+            containsString("0.42s")
+        ));
+        assertThat(logs.getFirst().message(), not(containsString("failures")));
+        assertThat(logs.get(1).level(), is(Level.INFO));
+        assertThat(logs.get(1).message(), is("CREATE VIEW"));
+    }
+
+    @Test
+    void modelLogs_error_isErrorLevelWithFailureCount() {
+        var result = RunResult.Result.builder()
+            .status("error")
+            .message("Database Error in model fct_orders\n  relation \"raw_orders\" does not exist")
+            .failures(1)
+            .uniqueId("model.my_project.fct_orders")
+            .executionTime(0.13)
+            .build();
+
+        List<DynamicTaskRunLog> logs = ResultParser.modelLogs(result);
+
+        assertThat(logs, hasSize(2));
+        assertThat(logs.stream().allMatch(l -> l.level() == Level.ERROR), is(true));
+        assertThat(logs.getFirst().message(), allOf(
+            containsString("model.my_project.fct_orders"),
+            containsString("error"),
+            containsString("1 failure")
+        ));
+        // singular: exactly "1 failure", not "1 failures"
+        assertThat(logs.getFirst().message(), not(containsString("failures")));
+        assertThat(logs.get(1).message(), containsString("Database Error"));
+    }
+
+    @Test
+    void modelLogs_multipleFailures_pluralizes() {
+        var result = RunResult.Result.builder()
+            .status("fail")
+            .failures(3)
+            .uniqueId("test.my_project.accepted_values_status")
+            .build();
+
+        List<DynamicTaskRunLog> logs = ResultParser.modelLogs(result);
+
+        assertThat(logs.getFirst().level(), is(Level.ERROR));
+        assertThat(logs.getFirst().message(), containsString("3 failures"));
+    }
+
+    @Test
+    void modelLogs_warning_isWarnLevelSummaryOnlyWhenNoMessage() {
+        var result = RunResult.Result.builder()
+            .status("warn")
+            .uniqueId("model.my_project.snapshot")
+            .build();
+
+        List<DynamicTaskRunLog> logs = ResultParser.modelLogs(result);
+
+        // no message, no execution time, no failures => only the summary line
+        assertThat(logs, hasSize(1));
+        assertThat(logs.getFirst().level(), is(Level.WARN));
+        assertThat(logs.getFirst().message(), allOf(
+            containsString("model.my_project.snapshot"),
+            containsString("warn")
+        ));
+        assertThat(logs.getFirst().message(), not(containsString("failures")));
+    }
+
+    @Test
+    void modelLogs_zeroFailures_doesNotMentionFailures() {
+        var result = RunResult.Result.builder()
+            .status("pass")
+            .failures(0)
+            .uniqueId("test.my_project.not_null_orders")
+            .build();
+
+        List<DynamicTaskRunLog> logs = ResultParser.modelLogs(result);
+
+        assertThat(logs, hasSize(1));
+        assertThat(logs.getFirst().level(), is(Level.INFO));
+        assertThat(logs.getFirst().message(), not(containsString("failures")));
+    }
+}

--- a/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
@@ -3,11 +3,18 @@ package io.kestra.plugin.dbt;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
 
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.AssetEmit;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
@@ -16,6 +23,8 @@ import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.dbt.cli.DbtCLI;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import reactor.core.publisher.Flux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -24,6 +33,10 @@ import static org.hamcrest.Matchers.*;
 class ResultParserTest {
     @Inject
     private RunContextFactory runContextFactory;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    private QueueInterface<LogEntry> logQueue;
 
     @Test
     void parseManifestWithAssets_shouldEmitModelAssets() throws Exception {
@@ -232,6 +245,92 @@ class ResultParserTest {
         assertThat(fctOrdersEmit.inputs(), hasSize(1));
         assertThat(fctOrdersEmit.inputs().getFirst().id(), is("dev.intermediate.int_orders"));
         assertThat(fctOrdersEmit.outputs(), hasSize(0));
+    }
+
+    @Test
+    void parseRunResult_shouldEmitModelLogsUnderDynamicTaskRuns() throws Exception {
+        var runContext = mockRunContext();
+        var runResultsFile = runContext.workingDir().path(true).resolve("run_results.json");
+        Files.writeString(runResultsFile, """
+            {
+              "metadata": {
+                "dbt_version": "1.8.0"
+              },
+              "results": [
+                {
+                  "status": "success",
+                  "message": "CREATE VIEW",
+                  "failures": null,
+                  "unique_id": "model.my_project.stg_orders",
+                  "execution_time": 0.42,
+                  "adapter_response": {
+                    "rows_affected": "10"
+                  },
+                  "timing": [
+                    {"name": "compile", "started_at": "2024-01-01T00:00:00Z", "completed_at": "2024-01-01T00:00:01Z"},
+                    {"name": "execute", "started_at": "2024-01-01T00:00:01Z", "completed_at": "2024-01-01T00:00:02Z"}
+                  ]
+                },
+                {
+                  "status": "error",
+                  "message": "Database Error in model fct_orders\\n  relation \\"raw_orders\\" does not exist",
+                  "failures": 1,
+                  "unique_id": "model.my_project.fct_orders",
+                  "execution_time": 0.13,
+                  "adapter_response": {},
+                  "timing": [
+                    {"name": "compile", "started_at": "2024-01-01T00:00:02Z", "completed_at": "2024-01-01T00:00:03Z"},
+                    {"name": "execute", "started_at": "2024-01-01T00:00:03Z", "completed_at": "2024-01-01T00:00:04Z"}
+                  ]
+                }
+              ],
+              "elapsed_time": 1.23
+            }
+            """);
+
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+
+        ResultParser.parseRunResult(runContext, runResultsFile.toFile(), null);
+
+        // The model logs are attributed to each model's own dynamic taskrun, never the parent root.
+        String parentTaskRunId = runContext.render("{{ taskrun.id }}");
+        Set<String> modelTaskRunIds = runContext.dynamicWorkerResults().stream()
+            .map(r -> r.getTaskRun().getId())
+            .collect(Collectors.toSet());
+        assertThat(modelTaskRunIds, hasSize(2));
+        assertThat(modelTaskRunIds, not(hasItem(parentTaskRunId)));
+
+        TestsUtils.awaitLog(logs, l -> l.getTaskRunId() != null && modelTaskRunIds.contains(l.getTaskRunId()));
+        receive.blockLast();
+
+        List<LogEntry> modelLogs = List.copyOf(logs).stream()
+            .filter(l -> l.getTaskRunId() != null && modelTaskRunIds.contains(l.getTaskRunId()))
+            .toList();
+
+        assertThat(modelLogs, is(not(empty())));
+        // single-attempt dynamic taskruns: their logs live under attempt 0
+        assertThat(modelLogs.stream().allMatch(l -> l.getAttemptNumber() != null && l.getAttemptNumber() == 0), is(true));
+
+        // success model: a summary line carrying its uniqueId + status, logged at INFO under its own bar
+        List<LogEntry> successLogs = modelLogs.stream()
+            .filter(l -> "model.my_project.stg_orders".equals(l.getTaskId()))
+            .toList();
+        assertThat(successLogs, is(not(empty())));
+        assertThat(successLogs.stream().allMatch(l -> l.getLevel() == Level.INFO), is(true));
+        assertThat(
+            successLogs.stream().anyMatch(l -> l.getMessage().contains("success")),
+            is(true)
+        );
+
+        // failing model: ERROR level, the failure count and the dbt error message under its own bar
+        List<LogEntry> errorLogs = modelLogs.stream()
+            .filter(l -> l.getLevel() == Level.ERROR)
+            .toList();
+        assertThat(errorLogs, is(not(empty())));
+        assertThat(errorLogs.stream().allMatch(l -> "model.my_project.fct_orders".equals(l.getTaskId())), is(true));
+        assertThat(errorLogs.stream().anyMatch(l -> l.getMessage().contains("1 failure")), is(true));
+        assertThat(errorLogs.stream().anyMatch(l -> l.getMessage().contains("Database Error")), is(true));
     }
 
     private static AssetEmit findEmitWithOutput(List<AssetEmit> emitted, String outputId) {

--- a/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
@@ -12,6 +12,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
 
 import jakarta.inject.Inject;
 
@@ -124,20 +125,7 @@ class MockTriggerRunTest {
             .wait(Property.ofValue(true))
             .build();
 
-        RunContext runContext = runContextFactory.of(
-            Map.of(
-                "flow", Map.of(
-                    "id", "my-flow",
-                    "namespace", "my.namespace"
-                ),
-                "execution", Map.of(
-                    "id", "exec-123"
-                ),
-                "taskrun", Map.of(
-                    "id", "taskrun-123"
-                )
-            )
-        );
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
         TriggerRun.Output output = task.run(runContext);
 
         assertThat(output, is(notNullValue()));


### PR DESCRIPTION
## What

Makes each dbt model's logs (status, message, errors) render inline **under that model's own dynamic taskrun bar** in the Logs/Gantt views, instead of all landing on the parent task's root taskrun.

`ResultParser.parseRunResult` already emits one dynamic taskrun per dbt model (the UI timeline "bars"), but those bars carried **no logs**. This attaches per-model log lines to each bar, so a failing model shows its `ERROR` lines under its own (red) bar.

## How

Instead of collecting all `WorkerTaskResult`s and calling `runContext.dynamicWorkerResult(list)` once, emit per model with the per-taskrun overload added for the Ansible fix:

```java
runContext.dynamicWorkerResult(
    WorkerTaskResult.builder().taskRun(modelTaskRun).build(),
    modelLogs(r)
);
```

`modelLogs(RunResult.Result)` builds, per model:
- a summary line — `uniqueId => status`, execution time, and `(N failure[s])` when `failures > 0`;
- the model `message` when non-blank (SQL/compile errors, dbt status messages).

Level comes from `r.state()`: `FAILED` → `ERROR`, `WARNING` → `WARN`, else `INFO`. The plugin passes only `level` + `message`; core builds the `LogEntry`, forcing execution/tenant/namespace/flow from the run context, fixing `attemptNumber` to 0, masking secrets and routing through the regular appender pipeline (the plugin never builds a `LogEntry`).

The same change also **drops the `value`** on the model taskruns (it was copied boilerplate set to the parent taskrun id, surfacing a meaningless UUID subtitle). `taskId` is already the model `uniqueId` and identifies the bar — same call made in the Ansible plugin.

### Notes
- **No double-logging.** `rows_affected` / `bytes_processed` stay metrics-only (no duplicate log line). Live stdout streaming via `DbtLogConsumer` → `LogService.parse` is left untouched — the new lines are structured post-hoc content from `run_results.json`, not a duplicate of the live stream, so there is nothing to drop (dbt has no equivalent duplicate root print to the one removed in the Ansible fix).
- **No frontend work.** Logs/Gantt parent→child nesting + indentation ships in the core PR and applies to any plugin's dynamic taskruns automatically (dbt already sets `parentTaskRunId`).

## ⚠️ Blocked on core release — draft, do not merge yet

This depends on the core API added for the Ansible fix in **kestra-io/kestra#16898**:

```java
public record DynamicTaskRunLog(org.slf4j.event.Level level, String message) {}
void RunContext.dynamicWorkerResult(WorkerTaskResult workerTaskResult, List<DynamicTaskRunLog> logs);
```

That API is **not yet released**. `gradle.properties` pins `kestraVersion=1.3.26` — the planned 1.3.x backport release that ships it — so **CI cannot compile this PR until 1.3.26 is released**, at which point it should turn green and become merge-ready with no further changes. (The 1.3.x backport of #16898 is pure-additive but needs a `logEmitter`→`logQueue` adaptation, so it is tracked separately from a clean cherry-pick.)

The test's queue-capture idiom (`@Named(QueueFactoryInterface.WORKERTASKLOG_NAMED) QueueInterface<LogEntry>` + `TestsUtils.receive`) targets that 1.3.x release, matching `kestraVersion`.

## Tests

- `ResultParserModelLogsTest` — pure unit test for the per-model log lines (level + content, singular/plural failure wording). **Verified locally** by building against a `publishToMavenLocal` core SNAPSHOT containing #16898 (temporary version bump reverted before commit).
- `ResultParserTest.parseRunResult_shouldEmitModelLogsUnderDynamicTaskRuns` — `@KestraTest` integration test asserting the emitted `LogEntry`s carry the **model** sub-taskrun ids (not the parent) with `attemptNumber == 0`, the success model at `INFO` and the failing model at `ERROR`, with the expected per-model content. This compiles/runs only against the API-shipping core release, so it was **not run locally** — only the formatting helper test was.

Closes #276
Companion core PR: kestra-io/kestra#16898
Reference: kestra-io/plugin-ansible#99
