### PR TITLE
fix(ci): allow queued CI runs to stack instead of being dropped

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ on:
 concurrency:
   group: plugin-dbt-bigquery-tests
   cancel-in-progress: false
+  queue: max
 
 permissions:
   contents: write


### PR DESCRIPTION
The `concurrency` block on the Main workflow was added in 19b12e4 to
serialize CI runs against a shared BigQuery test table, using
`cancel-in-progress: false` so runs wouldn't be dropped.

GitHub Actions' default `queue: single` still cancels any previously
*pending* run when a newer one is queued in the same group, regardless
of `cancel-in-progress`. During bursts (rapid release pushes, several
dependabot PRs merging close together) this silently cancelled queued
CI runs with zero jobs ever executed.

`queue: max` (GH Actions, shipped 2026-05-07) lets up to 100 runs
queue instead of one, giving the originally intended semantics: never
run two at once, never drop a run.