### PR TITLE
fix: retry transient read timeouts when polling dbt Cloud run status

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.dbt.cloud;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -12,6 +13,7 @@ import io.kestra.core.http.HttpRequest;
 import io.kestra.core.http.HttpResponse;
 import io.kestra.core.http.client.HttpClient;
 import io.kestra.core.http.client.HttpClientException;
+import io.kestra.core.http.client.HttpClientRequestException;
 import io.kestra.core.http.client.HttpClientResponseException;
 import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.property.Property;
@@ -90,10 +92,7 @@ public abstract class AbstractDbtCloud extends Task {
                     .maxAttempts(rMaxRetries)
                     .build()
             ).run(
-                (res, throwable) -> throwable instanceof HttpClientResponseException ex &&
-                    (ex.getResponse().getStatus().getCode() == 502 ||
-                        ex.getResponse().getStatus().getCode() == 503 ||
-                        ex.getResponse().getStatus().getCode() == 504),
+                (res, throwable) -> isRetriableTransientError(throwable),
                 () ->
                 {
                     var response = client.request(request, String.class);
@@ -107,5 +106,32 @@ public abstract class AbstractDbtCloud extends Task {
                 }
             );
         }
+    }
+
+    /**
+     * Whether an error raised while calling the dbt Cloud API is transient and worth retrying.
+     *
+     * <p>Covers server-side 5xx responses, connection-level failures (socket/SSL) and read/connect
+     * timeouts. The core HTTP client wraps a read timeout as {@code RuntimeException(SocketTimeoutException)},
+     * so it is matched through the cause. Without this, a single timed-out status poll would fail the whole
+     * task even though the dbt Cloud run is still healthy. Genuine client errors (e.g. 4xx) are not retried.
+     */
+    static boolean isRetriableTransientError(Throwable throwable) {
+        if (throwable == null) {
+            return false;
+        }
+
+        if (throwable instanceof HttpClientResponseException ex) {
+            int code = ex.getResponse().getStatus().getCode();
+            return code == 502 || code == 503 || code == 504;
+        }
+
+        // Socket and SSL handshake failures are surfaced by the core HTTP client as this type.
+        if (throwable instanceof HttpClientRequestException) {
+            return true;
+        }
+
+        return throwable instanceof SocketTimeoutException
+            || throwable.getCause() instanceof SocketTimeoutException;
     }
 }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusRetryTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusRetryTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.dbt.cloud;
 
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.util.Map;
 
@@ -81,6 +82,92 @@ class CheckStatusRetryTest {
 
             var mockClient = mocked.constructed().getFirst();
             verify(mockClient, times(3)).request(any(HttpRequest.class), eq(String.class));
+        }
+    }
+
+    @Test
+    void shouldRetryOnReadTimeoutAndEventuallySucceed() throws Exception {
+        // Reproduces the false-failure ticket: a transient read timeout during status polling
+        // is surfaced by the core HTTP client as RuntimeException(SocketTimeoutException) and must
+        // be retried instead of failing the task while the dbt Cloud run is still healthy.
+        var runContext = runContextFactory.of(Map.of());
+        var requestBuilder = HttpRequest.builder()
+            .uri(new URI("https://fake.api/dbt"));
+
+        try (
+            var mocked = Mockito.mockConstruction(
+                HttpClient.class,
+                (mockClient, context) -> when(mockClient.request(any(HttpRequest.class), eq(String.class)))
+                    .thenThrow(new RuntimeException(new SocketTimeoutException("Read timed out")))
+                    .thenReturn(
+                        HttpResponse.<String> builder()
+                            .status(HttpResponse.Status.builder().code(200).build())
+                            .body("{\"status\":\"ok\"}")
+                            .build()
+                    )
+            )
+        ) {
+
+            var task = CheckStatus.builder()
+                .id(IdUtils.create())
+                .type(CheckStatus.class.getName())
+                .runId(Property.ofValue("123"))
+                .token(Property.ofValue("fake-token"))
+                .accountId(Property.ofValue("fake-account"))
+                .maxRetries(Property.ofValue(3))
+                .initialDelayMs(Property.ofValue(100L))
+                .build();
+
+            var response = task.request(runContext, requestBuilder, Map.class);
+
+            assertEquals(200, response.getStatus().getCode());
+            assertEquals("ok", response.getBody().get("status"));
+
+            var mockClient = mocked.constructed().getFirst();
+            verify(mockClient, times(2)).request(any(HttpRequest.class), eq(String.class));
+        }
+    }
+
+    @Test
+    void shouldNotRetryOnClientError() throws Exception {
+        // A genuine client error (e.g. 404 for a wrong run id) must fail fast, not retry.
+        var runContext = runContextFactory.of(Map.of());
+        var requestBuilder = HttpRequest.builder()
+            .uri(new URI("https://fake.api/dbt"));
+
+        try (
+            var mocked = Mockito.mockConstruction(
+                HttpClient.class,
+                (mockClient, context) -> when(mockClient.request(any(HttpRequest.class), eq(String.class)))
+                    .thenThrow(
+                        new HttpClientResponseException(
+                            "Not Found",
+                            HttpResponse.<String> builder()
+                                .status(HttpResponse.Status.builder().code(404).build())
+                                .build()
+                        )
+                    )
+            )
+        ) {
+
+            var task = CheckStatus.builder()
+                .id(IdUtils.create())
+                .type(CheckStatus.class.getName())
+                .runId(Property.ofValue("123"))
+                .token(Property.ofValue("fake-token"))
+                .accountId(Property.ofValue("fake-account"))
+                .maxRetries(Property.ofValue(3))
+                .initialDelayMs(Property.ofValue(100L))
+                .build();
+
+            var ex = assertThrows(
+                HttpClientResponseException.class,
+                () -> task.request(runContext, requestBuilder, Map.class)
+            );
+            assertEquals(404, ex.getResponse().getStatus().getCode());
+
+            var mockClient = mocked.constructed().getFirst();
+            verify(mockClient, times(1)).request(any(HttpRequest.class), eq(String.class));
         }
     }
 


### PR DESCRIPTION
## Problem

`io.kestra.plugin.dbt.cloud.CheckStatus` (and `TriggerRun` with `wait: true`) polls the dbt Cloud run status through `AbstractDbtCloud.request`, whose retry policy only retries **HTTP 502/503/504**. A transient read timeout during a status poll is surfaced by the core HTTP client as `RuntimeException(java.net.SocketTimeoutException)`, so it is not retried, propagates out of the polling loop, and fails the whole task — even though the dbt Cloud run is still healthy and goes on to complete:

```
ERROR java.net.SocketTimeoutException: Read timed out
    at io.kestra.core.http.client.HttpClient.request(HttpClient.java:294)
    at io.kestra.plugin.dbt.cloud.AbstractDbtCloud.lambda$request$1(AbstractDbtCloud.java:94)
    at io.kestra.plugin.dbt.cloud.CheckStatus.fetchRunResponse(CheckStatus.java:214)
    at io.kestra.plugin.dbt.cloud.CheckStatus.run(CheckStatus.java:118)
    at io.kestra.plugin.dbt.cloud.TriggerRun.run(TriggerRun.java:208)
```

The very next attempt of the same run completed `10 total | 10 success`, confirming there was no real dbt error — just a transient network read timeout on one poll.

## Root cause

The retry predicate in `AbstractDbtCloud.request` only matched `HttpClientResponseException` with status 502/503/504:

```java
(res, throwable) -> throwable instanceof HttpClientResponseException ex &&
    (code == 502 || code == 503 || code == 504)
```

A read timeout is not an `HttpClientResponseException`, so it never matched, was not retried, and failed the task.

## Fix

Broaden the retry predicate (extracted into `isRetriableTransientError`) to also treat as transient:

- connection-level failures — `HttpClientRequestException` (socket / SSL handshake);
- read/connect timeouts — `SocketTimeoutException`, including when wrapped as the cause.

Genuine client errors (4xx) still **fail fast** — no change there. Reuses the existing `maxRetries` / `initialDelayMs` config; no new properties. Benefits every request path (`CheckStatus` polling, `downloadArtifacts`, `TriggerRun`).

## Tests

`CheckStatusRetryTest`:
- `shouldRetryOnReadTimeoutAndEventuallySucceed` — reproduces the reported failure (`RuntimeException(SocketTimeoutException)` then `200`) and asserts retry + success. **Verified red without the fix** (`SocketTimeoutException: Read timed out`), green with it.
- `shouldNotRetryOnClientError` — asserts a `404` fails fast (single attempt, no retry).

Full `io.kestra.plugin.dbt.cloud` package: 14/14 green.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)
