### PR TITLE
fix(dbt-cloud): stop gating terminal run status on truncated_debug_logs

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -134,15 +134,9 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
 
                     var data = fetchRunResponse.get().getData();
 
-                    // we rely on truncated logs to be sure
-                    boolean allLogs = data.getRunSteps()
-                        .stream()
-                        .filter(step -> step.getTruncatedDebugLogs() != null)
-                        .count() == data.getRunSteps().size();
-
                     if (data.getStatus() == null && data.getIsComplete() == null && data.getStatusHumanized() == null) {
                         logger.warn("Received response with no status indicator from dbt Cloud — skipping this poll cycle");
-                    } else if (isEnded(data) && allLogs) {
+                    } else if (isEnded(data)) {
                         return fetchRunResponse.get();
                     }
                 }
@@ -152,6 +146,20 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
             runContext.render(this.pollFrequency).as(Duration.class).orElseThrow(),
             runContext.render(this.maxDuration).as(Duration.class).orElseThrow()
         );
+
+        // Polling always requests debug=false to keep every intermediate poll lightweight. Now that the
+        // run has reached a terminal status, do one best-effort fetch with debug=true to pick up the
+        // fullest available step logs (e.g. truncated_debug_logs), whose population timing is not part
+        // of dbt Cloud's terminal-run contract. A failure here must not turn an otherwise successful run
+        // into a failure, so fall back to the response already collected while polling.
+        try {
+            Optional<RunResponse> debugRunResponse = fetchRunResponse(runContext, runIdRendered, true);
+            if (debugRunResponse.isPresent()) {
+                finalRunResponse = debugRunResponse.get();
+            }
+        } catch (IllegalVariableEvaluationException | HttpClientException | IOException e) {
+            logger.debug("Unable to fetch final debug logs for run '{}' — falling back to logs collected during polling", runIdRendered, e);
+        }
 
         // final response
         logSteps(logger, finalRunResponse);

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -147,13 +147,10 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
             runContext.render(this.maxDuration).as(Duration.class).orElseThrow()
         );
 
-        // Polling always requests debug=false to keep every intermediate poll lightweight. Now that the
-        // run has reached a terminal status, do one best-effort fetch with debug=true to pick up the
-        // fullest available step logs (e.g. truncated_debug_logs), whose population timing is not part
-        // of dbt Cloud's terminal-run contract. A failure here must not turn an otherwise successful run
-        // into a failure, so fall back to the response already collected while polling.
+        // Best-effort debug=true fetch for fuller step logs; truncated_debug_logs population timing
+        // isn't part of dbt Cloud's terminal-run contract, so a failure here must not fail the run.
         try {
-            Optional<RunResponse> debugRunResponse = fetchRunResponse(runContext, runIdRendered, true);
+            var debugRunResponse = fetchRunResponse(runContext, runIdRendered, true);
             if (debugRunResponse.isPresent()) {
                 finalRunResponse = debugRunResponse.get();
             }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
@@ -1,19 +1,27 @@
 package io.kestra.plugin.dbt.cloud;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.jupiter.api.Test;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import reactor.core.publisher.Flux;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,6 +36,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CheckStatusTest {
     @Inject
     private RunContextFactory runContextFactory;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    private QueueInterface<LogEntry> logQueue;
 
     @Test
     void run() throws Exception {
@@ -389,5 +401,158 @@ class CheckStatusTest {
         assertThat(output, is(notNullValue()));
         // Must complete well inside maxDuration (5s), not spin until the timeout.
         assertThat(elapsed < Duration.ofSeconds(5).toMillis(), is(true));
+    }
+
+    /**
+     * Regression test: the best-effort debug=true fetch done once the run is terminal must not fail
+     * the task when it errors out. The run must still succeed using the response already collected
+     * during polling.
+     */
+    @Test
+    void shouldFallBackToPolledResponseWhenFinalDebugFetchFails() throws Exception {
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/2222/"))
+                .withQueryParam("include_related", notContaining("debug_logs"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 2222,
+                            "status": 10,
+                            "status_humanized": "Success",
+                            "duration_humanized": "1s",
+                            "run_steps": [{ "id": 1, "name": "dbt run", "logs": "polled step output" }]
+                          }
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/2222/"))
+                .withQueryParam("include_related", containing("debug_logs"))
+                .willReturn(aResponse().withStatus(400).withBody("Bad Request"))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/2222/artifacts/run_results.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/2222/artifacts/manifest.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        CheckStatus checkStatus = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .baseUrl(Property.ofValue("http://localhost:8089"))
+            .runId(Property.ofValue("2222"))
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .parseRunResults(Property.ofValue(false))
+            .build();
+
+        RunContext runContext = mockRunContext(checkStatus);
+
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+
+        // Must not throw despite the debug=true follow-up fetch failing with a 400.
+        CheckStatus.Output output = checkStatus.run(runContext);
+
+        TestsUtils.awaitLog(logs, l -> l.getMessage() != null && l.getMessage().contains("polled step output"));
+        receive.blockLast();
+
+        assertThat(output, is(notNullValue()));
+        assertThat(
+            logs.stream().anyMatch(l -> l.getMessage() != null && l.getMessage().contains("polled step output")),
+            is(true)
+        );
+    }
+
+    /**
+     * Happy path for the best-effort debug=true fetch: when it succeeds, its fuller step logs
+     * supersede the response collected during polling.
+     */
+    @Test
+    void shouldUseDebugResponseWhenFinalDebugFetchSucceeds() throws Exception {
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/1111/"))
+                .withQueryParam("include_related", notContaining("debug_logs"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 1111,
+                            "status": 10,
+                            "status_humanized": "Success",
+                            "duration_humanized": "1s",
+                            "run_steps": [{ "id": 1, "name": "dbt run", "logs": "short logs" }]
+                          }
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/1111/"))
+                .withQueryParam("include_related", containing("debug_logs"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 1111,
+                            "status": 10,
+                            "status_humanized": "Success",
+                            "duration_humanized": "1s",
+                            "run_steps": [{ "id": 1, "name": "dbt run", "logs": "short logs\\nfuller debug tail" }]
+                          }
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/1111/artifacts/run_results.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/1111/artifacts/manifest.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        CheckStatus checkStatus = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .baseUrl(Property.ofValue("http://localhost:8089"))
+            .runId(Property.ofValue("1111"))
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .parseRunResults(Property.ofValue(false))
+            .build();
+
+        RunContext runContext = mockRunContext(checkStatus);
+
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+
+        CheckStatus.Output output = checkStatus.run(runContext);
+
+        TestsUtils.awaitLog(logs, l -> l.getMessage() != null && l.getMessage().contains("fuller debug tail"));
+        receive.blockLast();
+
+        assertThat(output, is(notNullValue()));
+        // The fuller content only exists in the debug=true response — its presence in logs proves
+        // it superseded the response collected during polling.
+        assertThat(
+            logs.stream().anyMatch(l -> l.getMessage() != null && l.getMessage().contains("fuller debug tail")),
+            is(true)
+        );
+    }
+
+    private RunContext mockRunContext(CheckStatus task) {
+        var flow = TestsUtils.mockFlow();
+        var execution = TestsUtils.mockExecution(flow, Map.of(), null);
+        var taskRun = TestsUtils.mockTaskRun(execution, task);
+        return runContextFactory.of(flow, task, execution, taskRun, false);
     }
 }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
@@ -326,4 +326,68 @@ class CheckStatusTest {
         CheckStatus.Output output = checkStatus.run(runContext);
         assertThat(output, is(notNullValue()));
     }
+
+    /**
+     * Regression test: a run that reaches a terminal status on the very first poll must return
+     * immediately, even when a run step's truncated_debug_logs never populates. Before the fix, the
+     * loop's return condition was `isEnded(data) && allLogs`, so a run step whose
+     * truncated_debug_logs stays null would spin until maxDuration and throw a timeout instead of
+     * surfacing the already-known terminal status.
+     */
+    @Test
+    void shouldSucceedImmediatelyWhenTruncatedDebugLogsNeverPopulate() throws Exception {
+        stubFor(
+            get(urlMatching("/api/v2/accounts/123/runs/3333/\\?.*"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 3333,
+                            "status": 10,
+                            "status_humanized": "Success",
+                            "duration_humanized": "1s",
+                            "run_steps": [
+                              {
+                                "id": 1,
+                                "name": "dbt run",
+                                "logs": "some logs",
+                                "truncated_debug_logs": null
+                              }
+                            ]
+                          }
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/3333/artifacts/run_results.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/3333/artifacts/manifest.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        CheckStatus checkStatus = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .baseUrl(Property.ofValue("http://localhost:8089"))
+            .runId(Property.ofValue("3333"))
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .pollFrequency(Property.ofValue(Duration.ofMillis(100)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .parseRunResults(Property.ofValue(false))
+            .build();
+
+        long start = System.currentTimeMillis();
+        CheckStatus.Output output = checkStatus.run(runContext);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(output, is(notNullValue()));
+        // Must complete well inside maxDuration (5s), not spin until the timeout.
+        assertThat(elapsed < Duration.ofSeconds(5).toMillis(), is(true));
+    }
 }


### PR DESCRIPTION
## Summary

- `CheckStatus.run()`'s polling loop only returned when `isEnded(data) && allLogs`, where `allLogs` required every `run_steps[]` entry to carry a non-null `truncated_debug_logs`. That field's population timing is not part of dbt Cloud's terminal-run contract, and the polling call always requests `debug=false` (no call site ever passes `debug=true`), so a run could sit polling — and eventually time out — after it had already reached a known terminal status.
- The loop's return condition is now `isEnded(data)` alone; terminal status is detected via the existing integer `status` → `is_complete` → `status_humanized` precedence chain.
- After the loop returns, one best-effort follow-up fetch with `debug=true` picks up the fullest available step logs (e.g. `truncated_debug_logs`) before computing the success/failure verdict. If that fetch fails for any reason, the task falls back to the response already collected during polling instead of failing an otherwise-successful run.
- Removed the now-dead `allLogs` computation and its comment.
- Added a regression test (`shouldSucceedImmediatelyWhenTruncatedDebugLogsNeverPopulate`) stubbing a run whose status is terminal on the very first poll but whose single run step's `truncated_debug_logs` stays `null` — asserts the run completes well inside `maxDuration` instead of spinning to a timeout.

part-of: https://github.com/kestra-io/kestra-ee/issues/8852

## Test plan

- [x] `rtk test ./gradlew test` passes (full suite, including `CheckStatusTest`, `CheckStatusRetryTest`, `MockTriggerRunTest`)
- [ ] `./gradlew shadowJar` builds

---
*[View as Artifact](https://claude.ai/code/artifact/c8dbcbce-f830-4813-9ba6-ace5da308d85)*