### PR TITLE
docs(dbt): fix branding, cloud auth wording, and deprecation note

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/AbstractDbt.java
@@ -76,7 +76,7 @@ public abstract class AbstractDbt extends Task implements RunnableTask<ScriptOut
 
     @Schema(
         title = "The `profiles.yml` file content",
-        description = "If a `profile.yml` file already exist in the current working directory, it will be overridden."
+        description = "If a `profiles.yml` file already exists in the current working directory, it will be overridden."
     )
     Property<String> profiles;
 

--- a/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
+++ b/src/main/java/io/kestra/plugin/dbt/cli/DbtCLI.java
@@ -285,19 +285,19 @@ import lombok.experimental.SuperBuilder;
             name = "log.stats.success",
             type = Counter.TYPE,
             unit = "records",
-            description = "The number of successful log entries parsed from DBT output."
+            description = "The number of successful log entries parsed from dbt output."
         ),
         @Metric(
             name = "log.stats.warn",
             type = Counter.TYPE,
             unit = "records",
-            description = "The number of warning log entries parsed from DBT output."
+            description = "The number of warning log entries parsed from dbt output."
         ),
         @Metric(
             name = "log.stats.error",
             type = Counter.TYPE,
             unit = "records",
-            description = "The number of error log entries parsed from DBT output."
+            description = "The number of error log entries parsed from dbt output."
         )
     }
 )
@@ -349,6 +349,7 @@ public class DbtCLI extends AbstractExecScript implements RunnableTask<DbtCLI.Ou
 
     @Builder.Default
     @PluginProperty(group = "execution")
+    @Schema(title = "The task runner container image, only used if the task runner is container-based.")
     protected Property<String> containerImage = Property.ofValue(CORE_IMAGE);
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -46,12 +46,18 @@ public abstract class AbstractDbtCloud extends Task {
     @Builder.Default
     Property<String> baseUrl = Property.ofValue("https://cloud.getdbt.com");
 
-    @Schema(title = "Numeric ID of the account")
+    @Schema(
+        title = "Numeric ID of the account",
+        description = "The numeric dbt Cloud account ID, visible in the account settings and in the dbt Cloud URL."
+    )
     @NotNull
     @PluginProperty(group = "main")
     Property<String> accountId;
 
-    @Schema(title = "API key")
+    @Schema(
+        title = "API token",
+        description = "A dbt Cloud API token (a Service Account token or a Personal Access token); sent as a Bearer token."
+    )
     @NotNull
     @PluginProperty(group = "main", secret = true)
     Property<String> token;

--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -62,9 +62,9 @@ import io.kestra.core.models.annotations.PluginProperty;
                 tasks:
                   - id: check_status
                     type: io.kestra.plugin.dbt.cloud.CheckStatus
-                    accountId: "dbt_account"
+                    accountId: "12345"
                     token: "{{ secret('DBT_TOKEN') }}"
-                    runId: "run_id"
+                    runId: "98765"
                 """
         )
     }

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -47,9 +47,9 @@ import io.kestra.core.models.annotations.PluginProperty;
                 tasks:
                   - id: trigger_run
                     type: io.kestra.plugin.dbt.cloud.TriggerRun
-                    accountId: "dbt_account"
+                    accountId: "12345"
                     token: "{{ secret('DBT_TOKEN') }}"
-                    jobId: "job_id"
+                    jobId: "67890"
                 """
         )
     }

--- a/src/main/resources/doc/io.kestra.plugin.dbt.md
+++ b/src/main/resources/doc/io.kestra.plugin.dbt.md
@@ -4,7 +4,7 @@ The `DbtCLI` task runs any dbt command inside a configurable container and parse
 
 ## Authentication
 
-Authentication to your data warehouse lives in the `profiles` property, which accepts the full content of a `profiles.yml` file as an inline string. Use `{{ secret('NAME') }}` to inject credentials at runtime rather than hardcoding them. For a cleaner separation of configuration from flow logic, store `profiles.yml` as a [namespace file](https://kestra.io/docs/concepts/namespace-files) and reference it with namespace file functions.
+Authentication to your data warehouse lives in the `profiles` property, which accepts the full content of a `profiles.yml` file as an inline string. Use [`{{ secret('NAME') }}`](https://kestra.io/docs/concepts/secret) to inject credentials at runtime rather than hardcoding them. For a cleaner separation of configuration from flow logic, store `profiles.yml` as a [namespace file](https://kestra.io/docs/concepts/namespace-files) and reference it with namespace file functions.
 
 ## Common properties
 
@@ -12,6 +12,6 @@ All CLI tasks run in a container defined by `containerImage`. Use an image from 
 
 ## Tasks
 
-`DbtCLI` is the primary task and runs any dbt CLI command. For state-based selection across runs, `storeManifest` and `loadManifest` persist `manifest.json` to and from the Kestra KV Store. Dedicated tasks for individual commands (`Build`, `Run`, `Test`, `Seed`, and others) are also available if you prefer a more explicit task structure.
+`DbtCLI` is the primary task and runs any dbt CLI command. For state-based selection across runs, `storeManifest` and `loadManifest` persist `manifest.json` to and from the Kestra KV Store. Dedicated per-command tasks (`Run`, `Test`, `Seed`, `Build`, and others) also exist but are **deprecated** — use `DbtCLI` with the corresponding dbt command (for example `commands: ["dbt build"]`) instead.
 
-For dbt Cloud, use `TriggerRun` — it starts a job and waits for completion by default without requiring a container. Use `CheckStatus` to poll a run that was triggered outside of Kestra.
+For dbt Cloud, use `TriggerRun` — it starts a job and waits for completion by default without requiring a container. Use `CheckStatus` to poll a run that was triggered outside of Kestra. Authenticate dbt Cloud tasks with `accountId` (your numeric dbt Cloud account ID) and `token` (a dbt Cloud API token, supplied via `{{ secret('NAME') }}`).

--- a/src/main/resources/metadata/cli.yaml
+++ b/src/main/resources/metadata/cli.yaml
@@ -1,6 +1,6 @@
 group: io.kestra.plugin.dbt.cli
 name: "cli"
-title: "Dbt CLI"
+title: "dbt CLI"
 description: "Tasks that run dbt via the CLI for building, testing, and managing projects."
 body: "Wraps dbt commands (build, run, test, compile, seed, snapshot, deps, etc.) using container or custom task runners so you can orchestrate dbt projects alongside the rest of your Kestra pipeline—refresh models before downstream loads, validate data, or publish docs. Lets you provide project directories, a dbt binary path, profiles, and environment variables. Supports fail-fast, warn-error, run-result parsing, and storing artifacts for downstream steps."
 videos: []

--- a/src/main/resources/metadata/cloud.yaml
+++ b/src/main/resources/metadata/cloud.yaml
@@ -1,6 +1,6 @@
 group: io.kestra.plugin.dbt.cloud
 name: "cloud"
-title: "Dbt Cloud"
+title: "dbt Cloud"
 description: "Tasks that trigger and monitor dbt Cloud jobs through the API."
 body: "Use these tasks to start jobs, poll run state, and download artifacts like run_results.json and manifest.json. Requires baseUrl, accountId, token, and jobId or runId, with options to override git refs, targets, timeouts, and wait for completion while streaming logs and parsed run results."
 videos: []

--- a/src/main/resources/metadata/index.yaml
+++ b/src/main/resources/metadata/index.yaml
@@ -1,6 +1,6 @@
 group: io.kestra.plugin.dbt
 name: "dbt"
-title: "DBT"
+title: "dbt"
 description: "Integrate dbt data transformations into Kestra orchestration pipelines."
 body: "Provides dbt integrations for both CLI-driven projects and dbt Cloud jobs so you can orchestrate runs alongside other Kestra tasks. Supply your dbt profiles or Cloud API credentials to execute, monitor, and collect manifests and run results for downstream automation."
 videos: []


### PR DESCRIPTION
## Documentation review: plugin-dbt

Correctness/completeness pass over the `cli` subgroup (`DbtCLI` + 10 deprecated subcommand aliases) and `cloud` subgroup (`TriggerRun`, `CheckStatus`), the 3 metadata YAMLs, and the how-to doc. Reviewed via 3 subagents; inventory cross-checked against the registry. Documentation only; no runtime behavior changes. Code items are in the flag list.

### Branding — the product is lowercase "dbt"
- **`index.yaml`** title `"DBT"` → `"dbt"`; **`cli.yaml`** `"Dbt CLI"` → `"dbt CLI"`; **`cloud.yaml`** `"Dbt Cloud"` → `"dbt Cloud"`.
- **`DbtCLI`** `@Metric` descriptions said "parsed from **DBT** output" → "dbt output".

### dbt Cloud auth
- **`AbstractDbtCloud.token`** was titled **"API key"**, but it's a dbt Cloud API **token** (field is named `token`, sent as a Bearer token) → retitled "API token" with a description (Service Account or Personal Access token). Added a description to `accountId` (numeric account ID).
- **`CheckStatus`/`TriggerRun` examples** used non-numeric placeholders (`accountId: "dbt_account"`, `runId: "run_id"`, `jobId: "job_id"`) for numeric fields → numeric placeholders.
- **how-to** — the dbt Cloud section never explained authentication; added that `TriggerRun`/`CheckStatus` use `accountId` + `token` (via `{{ secret('NAME') }}`), and linked the `secret()` function.

### Deprecation
- **how-to** presented the per-command tasks (`Build`, `Run`, `Test`, `Seed`, …) as a valid "more explicit" alternative, but **all of them are `@Deprecated`** (each redirects to `DbtCLI`). Reworded to state they're deprecated and to use `DbtCLI` with the corresponding command.

### Other
- **`DbtCLI.containerImage`** re-declared the inherited field without `@Schema` (dropping its doc title) → restored the `@Schema`.
- **`AbstractDbt.profiles`** description said `profile.yml` (typo) / "already exist" → `profiles.yml` / "already exists".

Secret coverage is clean (`token` is `secret = true`; there is no `tokenURL` field here). The `cloud/models/*` DTOs are all internal Jackson response types (not surfaced as outputs, no `@Schema` needed); `TriggerRun`/`CheckStatus` outputs are documented. The 9 deprecated subcommand tasks are correct (no copy-paste).

---

## 🚩 Engineering flag list (not addressed here — code changes)
- **`AbstractRun` selector bug** — the `--selector` branch renders `this.target` instead of `this.selector`, so the documented `selector` property is silently ignored and `target` is used. Change `this.target` → `this.selector`.
- **`DbtCLI` metric names don't match runtime** — `@Metric` declares `log.stats.success`/`log.stats.warn`/`log.stats.error`, but the emitted metrics (via `LogService.parse`) use the raw dbt stats keys (`pass`, `warn`, `error`, `skip`, `total`, …). Users never see the declared names. Either prefix the emitted names or correct the declarations.
- **`AbstractDbtCloud.baseUrl`** has no `@PluginProperty(group)` while its sibling connection props use `group = "main"` — inconsistent grouping.
- **`cloud/JobScheduleDate`/`JobScheduleDateType`/`JobScheduleTime`/`JobScheduleTimeType`** are unreferenced dead code (not wired as task input anywhere).
- Deprecated `Setup` task has minor grammar issues (`provides` → `provide`) and a `containerImage` without `@Schema`; low priority given deprecation.