### PR TITLE
fix(dbt): emit per-model lineage with sources to avoid cartesian graph

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/ResultParser.java
+++ b/src/main/java/io/kestra/plugin/dbt/ResultParser.java
@@ -272,7 +272,7 @@ public abstract class ResultParser {
         if (manifest.getNodes() != null) {
             for (Map.Entry<String, Manifest.Node> entry : manifest.getNodes().entrySet()) {
                 Manifest.Node node = entry.getValue();
-                if (node == null || !PRODUCED_RESOURCE_TYPES.contains(lower(node.getResourceType()))) {
+                if (node == null || node.getResourceType() == null || !PRODUCED_RESOURCE_TYPES.contains(lower(node.getResourceType()))) {
                     continue;
                 }
 

--- a/src/main/java/io/kestra/plugin/dbt/ResultParser.java
+++ b/src/main/java/io/kestra/plugin/dbt/ResultParser.java
@@ -6,6 +6,8 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.*;
 
+import org.slf4j.event.Level;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -28,8 +30,6 @@ import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.dbt.models.Manifest;
 import io.kestra.plugin.dbt.models.RunResult;
 
-import org.slf4j.event.Level;
-
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 
 public abstract class ResultParser {
@@ -38,6 +38,12 @@ public abstract class ResultParser {
 
     private static final String TABLE_ASSET_TYPE = "io.kestra.plugin.ee.assets.Table";
     private static final String RESOURCE_TYPE_MODEL = "model";
+    private static final String RESOURCE_TYPE_SEED = "seed";
+    private static final String RESOURCE_TYPE_SNAPSHOT = "snapshot";
+    private static final String RESOURCE_TYPE_SOURCE = "source";
+
+    // dbt node resource types that map to a physical table dbt builds.
+    private static final Set<String> PRODUCED_RESOURCE_TYPES = Set.of(RESOURCE_TYPE_MODEL, RESOURCE_TYPE_SEED, RESOURCE_TYPE_SNAPSHOT);
 
     public record ManifestResult(Manifest manifest, URI uri) {
     }
@@ -54,7 +60,7 @@ public abstract class ResultParser {
             RunResult.class
         );
 
-        Map<String, ModelAsset> modelAssets = manifest == null ? Map.of() : extractModelAssets(manifest);
+        Map<String, ModelAsset> modelAssets = manifest == null ? Map.of() : extractAssetNodes(manifest);
 
         // Emit one dynamic taskrun per dbt model (the UI timeline "bars"), attaching that model's
         // own status/message/failures as logs riding with its taskrun so they render inline under
@@ -198,23 +204,29 @@ public abstract class ResultParser {
         }
 
         ModelAsset modelAsset = modelAssets.get(uniqueId);
-        if (modelAsset == null) {
+        // A source can resolve here via `dbt source freshness` results and must never be this taskrun's output.
+        if (modelAsset == null || !modelAsset.produced()) {
             return null;
         }
 
         List<AssetIdentifier> inputs = inputIdentifiers(modelAsset, modelAssets);
-        List<Asset> outputs = outputAssets(modelAsset, modelAssets);
+        List<Asset> outputs = List.of(selfAsset(modelAsset));
 
         return new AssetsInOut(inputs, outputs);
     }
 
     private static void emitAssets(RunContext runContext, Manifest manifest) throws IllegalVariableEvaluationException {
-        Map<String, ModelAsset> modelAssets = extractModelAssets(manifest);
-        runContext.logger().info("dbt assets extracted from manifest: {}", modelAssets.size());
+        Map<String, ModelAsset> assetNodes = extractAssetNodes(manifest);
+        runContext.logger().info("dbt assets extracted from manifest: {}", assetNodes.size());
 
-        for (ModelAsset asset : modelAssets.values()) {
-            List<AssetIdentifier> inputs = inputIdentifiers(asset, modelAssets);
-            List<Asset> outputs = outputAssets(asset, modelAssets);
+        for (ModelAsset asset : assetNodes.values()) {
+            if (!asset.produced()) {
+                continue;
+            }
+
+            // Bundle is {parents} -> {this node} only (never children) so each event is self-contained, no cartesian join.
+            List<AssetIdentifier> inputs = inputIdentifiers(asset, assetNodes);
+            List<Asset> outputs = List.of(selfAsset(asset));
             try {
                 runContext.assets().emit(new AssetEmit(inputs, outputs));
             } catch (UnsupportedOperationException e) {
@@ -227,22 +239,12 @@ public abstract class ResultParser {
         }
     }
 
-    private static List<Asset> outputAssets(ModelAsset modelAsset, Map<String, ModelAsset> modelAssets) {
-        if (modelAsset.children() == null || modelAsset.children().isEmpty()) {
-            return List.of();
-        }
-
-        return modelAsset.children().stream()
-            .map(modelAssets::get)
-            .filter(Objects::nonNull)
-            .<Asset> map(
-                child -> Custom.builder()
-                    .id(child.assetId())
-                    .type(TABLE_ASSET_TYPE)
-                    .metadata(child.metadata())
-                    .build()
-            )
-            .toList();
+    private static Asset selfAsset(ModelAsset asset) {
+        return Custom.builder()
+            .id(asset.assetId())
+            .type(TABLE_ASSET_TYPE)
+            .metadata(asset.metadata())
+            .build();
     }
 
     private static List<AssetIdentifier> inputIdentifiers(ModelAsset modelAsset, Map<String, ModelAsset> modelAssets) {
@@ -257,79 +259,100 @@ public abstract class ResultParser {
             .toList();
     }
 
-    private static Map<String, ModelAsset> extractModelAssets(Manifest manifest) {
-        if (manifest == null || manifest.getNodes() == null || manifest.getNodes().isEmpty()) {
+    // Every model/seed/snapshot/source as an asset node keyed by unique_id, deps filtered to nodes in this set.
+    private static Map<String, ModelAsset> extractAssetNodes(Manifest manifest) {
+        if (manifest == null) {
             return Map.of();
         }
 
         String system = adapterType(manifest);
-        Map<String, ModelAsset> modelAssets = new HashMap<>();
+        Map<String, ModelAsset> assetNodes = new HashMap<>();
 
-        for (Map.Entry<String, Manifest.Node> entry : manifest.getNodes().entrySet()) {
-            Manifest.Node node = entry.getValue();
-            if (node == null || !RESOURCE_TYPE_MODEL.equalsIgnoreCase(node.getResourceType())) {
-                continue;
+        // Table-producing nodes (models, seeds, snapshots) from `nodes`.
+        if (manifest.getNodes() != null) {
+            for (Map.Entry<String, Manifest.Node> entry : manifest.getNodes().entrySet()) {
+                Manifest.Node node = entry.getValue();
+                if (node == null || !PRODUCED_RESOURCE_TYPES.contains(lower(node.getResourceType()))) {
+                    continue;
+                }
+
+                String uniqueId = firstNonBlank(node.getUniqueId(), entry.getKey());
+                if (uniqueId == null) {
+                    continue;
+                }
+
+                String name = firstNonBlank(node.getAlias(), node.getName(), uniqueId);
+                String assetId = assetIdFor(node.getDatabase(), node.getSchema(), name, uniqueId);
+
+                // Use parent_map from manifest (the canonical DAG) when available,
+                // falling back to node-level depends_on for older manifests.
+                List<String> dependsOn;
+                if (manifest.getParentMap() != null && manifest.getParentMap().containsKey(uniqueId)) {
+                    dependsOn = manifest.getParentMap().get(uniqueId);
+                } else if (node.getDependsOn() != null) {
+                    dependsOn = node.getDependsOn().getOrDefault("nodes", List.of());
+                } else {
+                    dependsOn = List.of();
+                }
+
+                assetNodes.put(uniqueId, new ModelAsset(assetId, metadataFor(system, node.getDatabase(), node.getSchema(), name), dependsOn, lower(node.getResourceType())));
             }
-
-            String uniqueId = firstNonBlank(node.getUniqueId(), entry.getKey());
-            if (uniqueId == null) {
-                continue;
-            }
-
-            String name = firstNonBlank(node.getAlias(), node.getName(), uniqueId);
-            String assetId = assetIdFor(node.getDatabase(), node.getSchema(), name, uniqueId);
-
-            Map<String, Object> metadata = new HashMap<>();
-            if (hasValue(system))
-                metadata.put("system", system);
-            if (hasValue(node.getDatabase()))
-                metadata.put("database", node.getDatabase());
-            if (hasValue(node.getSchema()))
-                metadata.put("schema", node.getSchema());
-            if (hasValue(name))
-                metadata.put("name", name);
-
-            // Use parent_map from manifest (the canonical DAG) when available,
-            // falling back to node-level depends_on for older manifests.
-            List<String> dependsOn;
-            if (manifest.getParentMap() != null && manifest.getParentMap().containsKey(uniqueId)) {
-                dependsOn = manifest.getParentMap().get(uniqueId);
-            } else if (node.getDependsOn() != null) {
-                dependsOn = node.getDependsOn().getOrDefault("nodes", List.of());
-            } else {
-                dependsOn = List.of();
-            }
-
-            modelAssets.put(uniqueId, new ModelAsset(assetId, metadata, dependsOn, List.of()));
         }
 
-        Map<String, ModelAsset> filtered = new HashMap<>(modelAssets.size());
-        for (Map.Entry<String, ModelAsset> e : modelAssets.entrySet()) {
+        // Sources (raw tables the project reads but does not build). Referenced as parents; no dependencies.
+        if (manifest.getSources() != null) {
+            for (Map.Entry<String, Manifest.Source> entry : manifest.getSources().entrySet()) {
+                Manifest.Source source = entry.getValue();
+                if (source == null) {
+                    continue;
+                }
+
+                String uniqueId = firstNonBlank(source.getUniqueId(), entry.getKey());
+                if (uniqueId == null) {
+                    continue;
+                }
+
+                // The physical table name is `identifier`; fall back to the dbt source name.
+                String name = firstNonBlank(source.getIdentifier(), source.getName(), uniqueId);
+                String assetId = assetIdFor(source.getDatabase(), source.getSchema(), name, uniqueId);
+
+                assetNodes.put(uniqueId, new ModelAsset(assetId, metadataFor(system, source.getDatabase(), source.getSchema(), name), List.of(), RESOURCE_TYPE_SOURCE));
+            }
+        }
+
+        // Keep only dependencies that resolve to a known asset node in this set.
+        Map<String, ModelAsset> resolved = new HashMap<>(assetNodes.size());
+        for (Map.Entry<String, ModelAsset> e : assetNodes.entrySet()) {
             ModelAsset a = e.getValue();
             List<String> deps = a.dependsOn() == null ? List.of()
                 : a.dependsOn().stream()
-                    .filter(modelAssets::containsKey)
+                    .filter(assetNodes::containsKey)
                     .toList();
-            filtered.put(e.getKey(), new ModelAsset(a.assetId(), a.metadata(), deps, List.of()));
+            resolved.put(e.getKey(), new ModelAsset(a.assetId(), a.metadata(), deps, a.resourceType()));
         }
 
-        // Compute reverse dependencies (children: models that depend on this one)
-        Map<String, List<String>> childrenMap = new HashMap<>();
-        for (Map.Entry<String, ModelAsset> e : filtered.entrySet()) {
-            for (String dep : e.getValue().dependsOn()) {
-                childrenMap.computeIfAbsent(dep, k -> new ArrayList<>()).add(e.getKey());
-            }
-        }
+        return resolved;
+    }
 
-        // Rebuild with children populated
-        Map<String, ModelAsset> result = new HashMap<>(filtered.size());
-        for (Map.Entry<String, ModelAsset> e : filtered.entrySet()) {
-            ModelAsset a = e.getValue();
-            List<String> children = childrenMap.getOrDefault(e.getKey(), List.of());
-            result.put(e.getKey(), new ModelAsset(a.assetId(), a.metadata(), a.dependsOn(), children));
+    private static Map<String, Object> metadataFor(String system, String database, String schema, String name) {
+        Map<String, Object> metadata = new HashMap<>();
+        if (hasValue(system)) {
+            metadata.put("system", system);
         }
+        if (hasValue(database)) {
+            metadata.put("database", database);
+        }
+        if (hasValue(schema)) {
+            metadata.put("schema", schema);
+        }
+        if (hasValue(name)) {
+            metadata.put("name", name);
+        }
+        return metadata;
+    }
 
-        return result;
+    private static String lower(String value) {
+        return value == null ? null : value.toLowerCase(Locale.ROOT);
     }
 
     private static String adapterType(Manifest manifest) {
@@ -373,6 +396,10 @@ public abstract class ResultParser {
         return value != null && !value.trim().isEmpty();
     }
 
-    private record ModelAsset(String assetId, Map<String, Object> metadata, List<String> dependsOn, List<String> children) {
+    private record ModelAsset(String assetId, Map<String, Object> metadata, List<String> dependsOn, String resourceType) {
+        // True for nodes dbt builds (models, seeds, snapshots), not read-only sources.
+        boolean produced() {
+            return PRODUCED_RESOURCE_TYPES.contains(resourceType);
+        }
     }
 }

--- a/src/main/java/io/kestra/plugin/dbt/models/Manifest.java
+++ b/src/main/java/io/kestra/plugin/dbt/models/Manifest.java
@@ -16,6 +16,9 @@ public class Manifest {
     Map<String, Object> metadata;
     Map<String, Node> nodes;
 
+    // Sources are raw tables dbt reads but does not build, resolved so model-to-source edges survive.
+    Map<String, Source> sources;
+
     @JsonProperty("parent_map")
     Map<String, List<String>> parentMap;
 
@@ -39,6 +42,23 @@ public class Manifest {
 
         @JsonProperty("depends_on")
         Map<String, List<String>> dependsOn;
+
+        @JsonProperty("unique_id")
+        String uniqueId;
+    }
+
+    @Value
+    @Jacksonized
+    @SuperBuilder
+    public static class Source {
+        String database;
+
+        String schema;
+
+        String name;
+
+        // The physical table name of the source. Prefer this over `name` (the dbt source name) when present.
+        String identifier;
 
         @JsonProperty("unique_id")
         String uniqueId;

--- a/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
@@ -306,6 +306,28 @@ class ResultParserTest {
     }
 
     @Test
+    void parseManifestWithAssets_shouldSkipNodeWithMissingResourceType() throws Exception {
+        var runContext = mockRunContext();
+        var manifestFile = runContext.workingDir().path(true).resolve("manifest.json");
+        // A node with no `resource_type` (partial/hand-edited manifest or dbt schema drift) must be skipped, not crash.
+        Files.writeString(manifestFile, """
+            {
+              "nodes": {
+                "model.p.good": {"unique_id": "model.p.good", "resource_type": "model", "database": "db", "schema": "s", "name": "good"},
+                "model.p.bad":  {"unique_id": "model.p.bad", "database": "db", "schema": "s", "name": "bad"}
+              },
+              "parent_map": {"model.p.good": [], "model.p.bad": []}
+            }
+            """);
+
+        ResultParser.parseManifestWithAssets(runContext, manifestFile.toFile());
+
+        // The node missing resource_type is skipped; only the valid model is emitted, no NPE.
+        assertThat(runContext.assets().emitted(), hasSize(1));
+        assertThat(findEmitWithOutput(runContext.assets().emitted(), "db.s.good"), is(notNullValue()));
+    }
+
+    @Test
     void parseRunResult_shouldEmitModelLogsUnderDynamicTaskRuns() throws Exception {
         var runContext = mockRunContext();
         var runResultsFile = runContext.workingDir().path(true).resolve("run_results.json");

--- a/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
@@ -264,7 +264,7 @@ class ResultParserTest {
         // Each event is {parents} -> {the model itself}, one output per event.
 
         // stg_orders: its only parent is a source that this manifest never defines in `sources`,
-        // so it is dropped; stg_orders has no resolvable inputs.
+        // so it is dropped, leaving stg_orders with no resolvable inputs.
         var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "dev.staging.stg_orders");
         assertThat(stgOrdersEmit, is(notNullValue()));
         assertThat(stgOrdersEmit.inputs(), hasSize(0));

--- a/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
@@ -12,12 +12,14 @@ import org.slf4j.event.Level;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.AssetEmit;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.dbt.cli.DbtCLI;
@@ -37,6 +39,40 @@ class ResultParserTest {
     @Inject
     @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
     private QueueInterface<LogEntry> logQueue;
+
+    // One model reading one source, shared by the source-lineage tests.
+    private static final String SOURCE_MANIFEST_JSON = """
+        {
+          "metadata": {
+            "adapter_type": "postgres"
+          },
+          "nodes": {
+            "model.analytics.stg_orders": {
+              "resource_type": "model",
+              "database": "analytics",
+              "schema": "staging",
+              "name": "stg_orders",
+              "unique_id": "model.analytics.stg_orders",
+              "depends_on": {
+                "nodes": ["source.analytics.raw.orders"]
+              }
+            }
+          },
+          "sources": {
+            "source.analytics.raw.orders": {
+              "database": "analytics",
+              "schema": "raw",
+              "name": "orders",
+              "identifier": "orders",
+              "resource_type": "source",
+              "unique_id": "source.analytics.raw.orders"
+            }
+          },
+          "parent_map": {
+            "model.analytics.stg_orders": ["source.analytics.raw.orders"]
+          }
+        }
+        """;
 
     @Test
     void parseManifestWithAssets_shouldEmitModelAssets() throws Exception {
@@ -85,23 +121,28 @@ class ResultParserTest {
         assertThat(manifestResult.manifest(), is(notNullValue()));
         assertThat(runContext.assets().emitted(), hasSize(2));
 
-        // stg_orders has no inputs and 1 output (fct_orders, its child)
-        // fct_orders has 1 input (stg_orders) and no outputs (leaf node)
-        var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.fct_orders");
+        // Each model emits one bundle: {its parents} -> {the model itself}.
+        // stg_orders: no parents, output is stg_orders.
+        var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.staging.stg_orders");
         assertThat("stg_orders emission should exist", stgOrdersEmit, is(notNullValue()));
         assertThat(stgOrdersEmit.inputs(), hasSize(0));
         assertThat(stgOrdersEmit.outputs(), hasSize(1));
 
-        var fctOrdersOutput = stgOrdersEmit.outputs().getFirst();
-        assertThat(fctOrdersOutput.getMetadata().get("system"), is("postgres"));
-        assertThat(fctOrdersOutput.getMetadata().get("database"), is("analytics"));
-        assertThat(fctOrdersOutput.getMetadata().get("schema"), is("marts"));
-        assertThat(fctOrdersOutput.getMetadata().get("name"), is("fct_orders"));
+        var stgOrdersOutput = stgOrdersEmit.outputs().getFirst();
+        assertThat(stgOrdersOutput.getMetadata().get("system"), is("postgres"));
+        assertThat(stgOrdersOutput.getMetadata().get("database"), is("analytics"));
+        assertThat(stgOrdersOutput.getMetadata().get("schema"), is("staging"));
+        assertThat(stgOrdersOutput.getMetadata().get("name"), is("stg_orders"));
 
-        var fctOrdersEmit = findEmitWithInput(runContext.assets().emitted(), "analytics.staging.stg_orders");
+        // fct_orders: parent stg_orders -> model fct_orders.
+        var fctOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.fct_orders");
         assertThat("fct_orders emission should exist", fctOrdersEmit, is(notNullValue()));
         assertThat(fctOrdersEmit.inputs(), hasSize(1));
-        assertThat(fctOrdersEmit.outputs(), hasSize(0));
+        assertThat(fctOrdersEmit.inputs().getFirst().id(), is("analytics.staging.stg_orders"));
+        assertThat(fctOrdersEmit.outputs(), hasSize(1));
+
+        // Every event has exactly one output (the model), so nothing can cross-join downstream.
+        assertThat(runContext.assets().emitted().stream().allMatch(e -> e.outputs().size() == 1), is(true));
     }
 
     @Test
@@ -150,18 +191,18 @@ class ResultParserTest {
 
         assertThat(runContext.assets().emitted(), hasSize(2));
 
-        // my_first_dbt_model: no inputs, 1 output (my_second_dbt_model)
-        var firstModelEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.my_second_dbt_model");
+        // my_first_dbt_model: no parents, output is itself.
+        var firstModelEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.my_first_dbt_model");
         assertThat(firstModelEmit, is(notNullValue()));
         assertThat(firstModelEmit.inputs(), hasSize(0));
         assertThat(firstModelEmit.outputs(), hasSize(1));
 
-        // my_second_dbt_model: 1 input (my_first_dbt_model), no outputs (leaf)
-        var secondModelEmit = findEmitWithInput(runContext.assets().emitted(), "analytics.marts.my_first_dbt_model");
+        // my_second_dbt_model: parent my_first_dbt_model -> model my_second_dbt_model.
+        var secondModelEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.my_second_dbt_model");
         assertThat(secondModelEmit, is(notNullValue()));
         assertThat(secondModelEmit.inputs(), hasSize(1));
         assertThat(secondModelEmit.inputs().getFirst().id(), is("analytics.marts.my_first_dbt_model"));
-        assertThat(secondModelEmit.outputs(), hasSize(0));
+        assertThat(secondModelEmit.outputs(), hasSize(1));
     }
 
     @Test
@@ -219,32 +260,49 @@ class ResultParserTest {
 
         assertThat(runContext.assets().emitted(), hasSize(3));
 
-        // DAG: stg_orders → int_orders → fct_orders (parent_map, no transitive edges)
-        // Inputs = upstream deps, Outputs = downstream children
+        // DAG from parent_map (no transitive edges): stg_orders -> int_orders -> fct_orders.
+        // Each event is {parents} -> {the model itself}, one output per event.
 
-        // stg_orders: no model inputs (source filtered out), 1 output (int_orders)
-        var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "dev.intermediate.int_orders");
+        // stg_orders: its only parent is a source that this manifest never defines in `sources`,
+        // so it is dropped; stg_orders has no resolvable inputs.
+        var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "dev.staging.stg_orders");
         assertThat(stgOrdersEmit, is(notNullValue()));
         assertThat(stgOrdersEmit.inputs(), hasSize(0));
         assertThat(stgOrdersEmit.outputs(), hasSize(1));
 
-        // int_orders: 1 input (stg_orders), 1 output (fct_orders)
-        var intOrdersEmit = findEmitWithInputAndOutput(
-            runContext.assets().emitted(),
-            "dev.staging.stg_orders", "dev.marts.fct_orders"
-        );
+        // int_orders: parent stg_orders -> model int_orders.
+        var intOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "dev.intermediate.int_orders");
         assertThat(intOrdersEmit, is(notNullValue()));
         assertThat(intOrdersEmit.inputs(), hasSize(1));
         assertThat(intOrdersEmit.inputs().getFirst().id(), is("dev.staging.stg_orders"));
         assertThat(intOrdersEmit.outputs(), hasSize(1));
-        assertThat(intOrdersEmit.outputs().getFirst().getId(), is("dev.marts.fct_orders"));
 
-        // fct_orders: 1 input (int_orders only, from parent_map), no outputs (leaf)
-        var fctOrdersEmit = findEmitWithInput(runContext.assets().emitted(), "dev.intermediate.int_orders");
+        // fct_orders: parent int_orders only (parent_map is the direct DAG) -> model fct_orders.
+        var fctOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "dev.marts.fct_orders");
         assertThat(fctOrdersEmit, is(notNullValue()));
         assertThat(fctOrdersEmit.inputs(), hasSize(1));
         assertThat(fctOrdersEmit.inputs().getFirst().id(), is("dev.intermediate.int_orders"));
-        assertThat(fctOrdersEmit.outputs(), hasSize(0));
+        assertThat(fctOrdersEmit.outputs(), hasSize(1));
+    }
+
+    @Test
+    void parseManifestWithAssets_shouldEmitModelToSourceEdges() throws Exception {
+        var runContext = mockRunContext();
+        var manifestFile = runContext.workingDir().path(true).resolve("manifest.json");
+        Files.writeString(manifestFile, SOURCE_MANIFEST_JSON);
+
+        ResultParser.parseManifestWithAssets(runContext, manifestFile.toFile());
+
+        // Only the model is emitted (a source is never built, so it emits no event of its own),
+        // but the source is preserved as the model's input, giving a real source -> model edge.
+        assertThat(runContext.assets().emitted(), hasSize(1));
+
+        var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.staging.stg_orders");
+        assertThat(stgOrdersEmit, is(notNullValue()));
+        assertThat(stgOrdersEmit.outputs(), hasSize(1));
+        assertThat(stgOrdersEmit.inputs(), hasSize(1));
+        // source assetId is database.schema.identifier
+        assertThat(stgOrdersEmit.inputs().getFirst().id(), is("analytics.raw.orders"));
     }
 
     @Test
@@ -333,24 +391,66 @@ class ResultParserTest {
         assertThat(errorLogs.stream().anyMatch(l -> l.getMessage().contains("Database Error")), is(true));
     }
 
+    @Test
+    void parseRunResult_shouldAttachModelAssetsButNotClaimSourceAsOutput() throws Exception {
+        var runContext = mockRunContext();
+
+        var manifestFile = runContext.workingDir().path(true).resolve("manifest.json");
+        Files.writeString(manifestFile, SOURCE_MANIFEST_JSON);
+        var manifest = ResultParser.parseManifestWithAssets(runContext, manifestFile.toFile()).manifest();
+
+        // run_results with a `dbt source freshness` entry for the source alongside the model build.
+        var runResultsFile = runContext.workingDir().path(true).resolve("run_results.json");
+        Files.writeString(runResultsFile, """
+            {
+              "metadata": {"dbt_version": "1.8.0"},
+              "results": [
+                {
+                  "status": "pass",
+                  "unique_id": "source.analytics.raw.orders",
+                  "execution_time": 0.1,
+                  "adapter_response": {},
+                  "timing": [
+                    {"name": "execute", "started_at": "2024-01-01T00:00:00Z", "completed_at": "2024-01-01T00:00:01Z"}
+                  ]
+                },
+                {
+                  "status": "success",
+                  "unique_id": "model.analytics.stg_orders",
+                  "execution_time": 0.2,
+                  "adapter_response": {},
+                  "timing": [
+                    {"name": "execute", "started_at": "2024-01-01T00:00:01Z", "completed_at": "2024-01-01T00:00:02Z"}
+                  ]
+                }
+              ],
+              "elapsed_time": 0.3
+            }
+            """);
+
+        ResultParser.parseRunResult(runContext, runResultsFile.toFile(), manifest);
+
+        Map<String, TaskRun> byTaskId = runContext.dynamicWorkerResults().stream()
+            .map(WorkerTaskResult::getTaskRun)
+            .collect(Collectors.toMap(TaskRun::getTaskId, tr -> tr));
+
+        // the model's dynamic taskrun carries {source} -> {the model itself}
+        TaskRun modelTaskRun = byTaskId.get("model.analytics.stg_orders");
+        assertThat(modelTaskRun, is(notNullValue()));
+        assertThat(modelTaskRun.getAssets(), is(notNullValue()));
+        assertThat(modelTaskRun.getAssets().getOutputs(), hasSize(1));
+        assertThat(modelTaskRun.getAssets().getOutputs().getFirst().getId(), is("analytics.staging.stg_orders"));
+        assertThat(modelTaskRun.getAssets().getInputs(), hasSize(1));
+        assertThat(modelTaskRun.getAssets().getInputs().getFirst().id(), is("analytics.raw.orders"));
+
+        // the source-freshness taskrun must NOT claim it produced the source table
+        TaskRun sourceTaskRun = byTaskId.get("source.analytics.raw.orders");
+        assertThat(sourceTaskRun, is(notNullValue()));
+        assertThat(sourceTaskRun.getAssets(), is(nullValue()));
+    }
+
     private static AssetEmit findEmitWithOutput(List<AssetEmit> emitted, String outputId) {
         return emitted.stream()
-            .filter(e -> e.outputs().stream().anyMatch(o -> o.getId().equals(outputId)))
-            .findFirst()
-            .orElse(null);
-    }
-
-    private static AssetEmit findEmitWithInput(List<AssetEmit> emitted, String inputId) {
-        return emitted.stream()
-            .filter(e -> e.inputs().stream().anyMatch(i -> i.id().equals(inputId)))
-            .filter(e -> e.outputs().isEmpty())
-            .findFirst()
-            .orElse(null);
-    }
-
-    private static AssetEmit findEmitWithInputAndOutput(List<AssetEmit> emitted, String inputId, String outputId) {
-        return emitted.stream()
-            .filter(e -> e.inputs().stream().anyMatch(i -> i.id().equals(inputId)))
             .filter(e -> e.outputs().stream().anyMatch(o -> o.getId().equals(outputId)))
             .findFirst()
             .orElse(null);

--- a/src/test/java/io/kestra/plugin/dbt/cli/RunnerTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cli/RunnerTest.java
@@ -48,77 +48,64 @@ class RunnerTest {
         assertThat("should emit exactly 8 model assets", allEmitted, hasSize(8));
 
         /*
-         * Expected lineage (inputs = upstream deps, outputs = downstream children):
+         * Each model emits one bundle: {its direct parents} -> {the model itself}. The model is the
+         * single output, so no downstream cartesian join is possible. Expected edges:
          *
-         * stg_customers: inputs=[] outputs=[int_customer_orders]
-         * stg_orders: inputs=[] outputs=[int_customer_orders, int_order_payments, int_daily_revenue]
-         * stg_payments: inputs=[] outputs=[int_order_payments, int_daily_revenue]
-         * int_customer_orders: inputs=[stg_customers, stg_orders] outputs=[fct_customer_summary]
-         * int_order_payments: inputs=[stg_orders, stg_payments] outputs=[fct_customer_summary]
-         * int_daily_revenue: inputs=[stg_orders, stg_payments] outputs=[fct_revenue_by_customer]
-         * fct_customer_summary: inputs=[int_customer_orders, int_order_payments] outputs=[fct_revenue_by_customer]
-         * fct_revenue_by_customer: inputs=[fct_customer_summary, int_daily_revenue] outputs=[]
+         * stg_customers parents=[] -> stg_customers
+         * stg_orders parents=[] -> stg_orders
+         * stg_payments parents=[] -> stg_payments
+         * int_customer_orders parents=[stg_customers, stg_orders] -> int_customer_orders
+         * int_order_payments parents=[stg_orders, stg_payments] -> int_order_payments
+         * int_daily_revenue parents=[stg_orders, stg_payments] -> int_daily_revenue
+         * fct_customer_summary parents=[int_customer_orders, int_order_payments] -> fct_customer_summary
+         * fct_revenue_by_customer parents=[fct_customer_summary, int_daily_revenue] -> fct_revenue_by_customer
          */
 
-        // Staging models: no inputs, outputs are the intermediate models they feed
-        assertEmission(
-            allEmitted, "stg_customers",
-            List.of(),
-            List.of("memory.main.int_customer_orders")
-        );
-        assertEmission(
-            allEmitted, "stg_orders",
-            List.of(),
-            List.of("memory.main.int_customer_orders", "memory.main.int_order_payments", "memory.main.int_daily_revenue")
-        );
-        assertEmission(
-            allEmitted, "stg_payments",
-            List.of(),
-            List.of("memory.main.int_order_payments", "memory.main.int_daily_revenue")
-        );
+        // Every event has exactly one output (the model itself).
+        assertThat(allEmitted.stream().allMatch(e -> e.outputs().size() == 1), is(true));
 
-        // Intermediate models: inputs from staging, outputs to marts
+        // Staging models: no parents.
+        assertEmission(allEmitted, "stg_customers", List.of());
+        assertEmission(allEmitted, "stg_orders", List.of());
+        assertEmission(allEmitted, "stg_payments", List.of());
+
+        // Intermediate models: parents are the staging models they read.
         assertEmission(
             allEmitted, "int_customer_orders",
-            List.of("memory.main.stg_customers", "memory.main.stg_orders"),
-            List.of("memory.main.fct_customer_summary")
+            List.of("memory.main.stg_customers", "memory.main.stg_orders")
         );
         assertEmission(
             allEmitted, "int_order_payments",
-            List.of("memory.main.stg_orders", "memory.main.stg_payments"),
-            List.of("memory.main.fct_customer_summary")
+            List.of("memory.main.stg_orders", "memory.main.stg_payments")
         );
         assertEmission(
             allEmitted, "int_daily_revenue",
-            List.of("memory.main.stg_orders", "memory.main.stg_payments"),
-            List.of("memory.main.fct_revenue_by_customer")
+            List.of("memory.main.stg_orders", "memory.main.stg_payments")
         );
 
-        // Mart models
+        // Mart models: parents are the intermediate/mart models they read.
         assertEmission(
             allEmitted, "fct_customer_summary",
-            List.of("memory.main.int_customer_orders", "memory.main.int_order_payments"),
-            List.of("memory.main.fct_revenue_by_customer")
+            List.of("memory.main.int_customer_orders", "memory.main.int_order_payments")
         );
         assertEmission(
             allEmitted, "fct_revenue_by_customer",
-            List.of("memory.main.fct_customer_summary", "memory.main.int_daily_revenue"),
-            List.of()
+            List.of("memory.main.fct_customer_summary", "memory.main.int_daily_revenue")
         );
     }
 
     /**
-     * Find the emission matching the expected inputs and outputs, then verify it.
+     * Assert exactly one emission exists whose single output is the given model and whose inputs are
+     * exactly the given parents.
      */
-    private static void assertEmission(List<AssetEmit> allEmitted, String modelName,
-        List<String> expectedInputIds, List<String> expectedOutputIds) {
-        // Find emission by matching expected inputs size and expected outputs
+    private static void assertEmission(List<AssetEmit> allEmitted, String modelName, List<String> expectedInputIds) {
+        String outputId = "memory.main." + modelName;
         AssetEmit matched = allEmitted.stream()
             .filter(emit ->
             {
-                Set<String> inputs = emit.inputs().stream().map(AssetIdentifier::id).collect(Collectors.toSet());
                 Set<String> outputs = emit.outputs().stream().map(Asset::getId).collect(Collectors.toSet());
-                return inputs.equals(Set.copyOf(expectedInputIds)) && outputs.equals(Set.copyOf(expectedOutputIds));
+                Set<String> inputs = emit.inputs().stream().map(AssetIdentifier::id).collect(Collectors.toSet());
+                return outputs.equals(Set.of(outputId)) && inputs.equals(Set.copyOf(expectedInputIds));
             })
             .findFirst()
             .orElse(null);


### PR DESCRIPTION
Emit per-model dbt lineage and keep sources, so the asset graph is not cartesian and shows source nodes.

- Emit one bundle per built node: the node as the single output, its parents as inputs.
- Parse manifest `sources`, resolve deps against models, sources, seeds and snapshots.
- `assetsFor` skips sources so `dbt source freshness` never claims to produce one.

Needs the companion core and ee PRs.

- closes: #306

- companion PR: kestra-io/kestra#18009
- companion PR: kestra-io/kestra-ee#9792
