### PR TITLE
fix(dbt): emit each dbt model as its own asset under enableAuto

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/ResultParser.java
+++ b/src/main/java/io/kestra/plugin/dbt/ResultParser.java
@@ -227,10 +227,8 @@ public abstract class ResultParser {
         }
     }
 
-    // Every dbt model is emitted as its own output asset; model-to-model edges are expressed
-    // as the downstream model's inputs (see inputIdentifiers), not as an upstream model's outputs.
-    // This ensures a model with no model-to-model dependency (e.g. reading only from a dbt source,
-    // or a single-model project) still surfaces as an asset instead of emitting nothing.
+    // Every dbt model is emitted as its own output asset. Model-to-model edges are the downstream
+    // model's inputs (see inputIdentifiers), so a model with no model dependency still surfaces.
     private static Asset modelOutputAsset(ModelAsset modelAsset) {
         return Custom.builder()
             .id(modelAsset.assetId())

--- a/src/main/java/io/kestra/plugin/dbt/ResultParser.java
+++ b/src/main/java/io/kestra/plugin/dbt/ResultParser.java
@@ -6,6 +6,8 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.*;
 
+import org.slf4j.event.Level;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -27,8 +29,6 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.dbt.models.Manifest;
 import io.kestra.plugin.dbt.models.RunResult;
-
-import org.slf4j.event.Level;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 
@@ -203,7 +203,7 @@ public abstract class ResultParser {
         }
 
         List<AssetIdentifier> inputs = inputIdentifiers(modelAsset, modelAssets);
-        List<Asset> outputs = outputAssets(modelAsset, modelAssets);
+        List<Asset> outputs = List.of(modelOutputAsset(modelAsset));
 
         return new AssetsInOut(inputs, outputs);
     }
@@ -214,7 +214,7 @@ public abstract class ResultParser {
 
         for (ModelAsset asset : modelAssets.values()) {
             List<AssetIdentifier> inputs = inputIdentifiers(asset, modelAssets);
-            List<Asset> outputs = outputAssets(asset, modelAssets);
+            List<Asset> outputs = List.of(modelOutputAsset(asset));
             try {
                 runContext.assets().emit(new AssetEmit(inputs, outputs));
             } catch (UnsupportedOperationException e) {
@@ -227,22 +227,16 @@ public abstract class ResultParser {
         }
     }
 
-    private static List<Asset> outputAssets(ModelAsset modelAsset, Map<String, ModelAsset> modelAssets) {
-        if (modelAsset.children() == null || modelAsset.children().isEmpty()) {
-            return List.of();
-        }
-
-        return modelAsset.children().stream()
-            .map(modelAssets::get)
-            .filter(Objects::nonNull)
-            .<Asset> map(
-                child -> Custom.builder()
-                    .id(child.assetId())
-                    .type(TABLE_ASSET_TYPE)
-                    .metadata(child.metadata())
-                    .build()
-            )
-            .toList();
+    // Every dbt model is emitted as its own output asset; model-to-model edges are expressed
+    // as the downstream model's inputs (see inputIdentifiers), not as an upstream model's outputs.
+    // This ensures a model with no model-to-model dependency (e.g. reading only from a dbt source,
+    // or a single-model project) still surfaces as an asset instead of emitting nothing.
+    private static Asset modelOutputAsset(ModelAsset modelAsset) {
+        return Custom.builder()
+            .id(modelAsset.assetId())
+            .type(TABLE_ASSET_TYPE)
+            .metadata(modelAsset.metadata())
+            .build();
     }
 
     private static List<AssetIdentifier> inputIdentifiers(ModelAsset modelAsset, Map<String, ModelAsset> modelAssets) {
@@ -300,7 +294,7 @@ public abstract class ResultParser {
                 dependsOn = List.of();
             }
 
-            modelAssets.put(uniqueId, new ModelAsset(assetId, metadata, dependsOn, List.of()));
+            modelAssets.put(uniqueId, new ModelAsset(assetId, metadata, dependsOn));
         }
 
         Map<String, ModelAsset> filtered = new HashMap<>(modelAssets.size());
@@ -310,26 +304,10 @@ public abstract class ResultParser {
                 : a.dependsOn().stream()
                     .filter(modelAssets::containsKey)
                     .toList();
-            filtered.put(e.getKey(), new ModelAsset(a.assetId(), a.metadata(), deps, List.of()));
+            filtered.put(e.getKey(), new ModelAsset(a.assetId(), a.metadata(), deps));
         }
 
-        // Compute reverse dependencies (children: models that depend on this one)
-        Map<String, List<String>> childrenMap = new HashMap<>();
-        for (Map.Entry<String, ModelAsset> e : filtered.entrySet()) {
-            for (String dep : e.getValue().dependsOn()) {
-                childrenMap.computeIfAbsent(dep, k -> new ArrayList<>()).add(e.getKey());
-            }
-        }
-
-        // Rebuild with children populated
-        Map<String, ModelAsset> result = new HashMap<>(filtered.size());
-        for (Map.Entry<String, ModelAsset> e : filtered.entrySet()) {
-            ModelAsset a = e.getValue();
-            List<String> children = childrenMap.getOrDefault(e.getKey(), List.of());
-            result.put(e.getKey(), new ModelAsset(a.assetId(), a.metadata(), a.dependsOn(), children));
-        }
-
-        return result;
+        return filtered;
     }
 
     private static String adapterType(Manifest manifest) {
@@ -373,6 +351,6 @@ public abstract class ResultParser {
         return value != null && !value.trim().isEmpty();
     }
 
-    private record ModelAsset(String assetId, Map<String, Object> metadata, List<String> dependsOn, List<String> children) {
+    private record ModelAsset(String assetId, Map<String, Object> metadata, List<String> dependsOn) {
     }
 }

--- a/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
@@ -85,23 +85,25 @@ class ResultParserTest {
         assertThat(manifestResult.manifest(), is(notNullValue()));
         assertThat(runContext.assets().emitted(), hasSize(2));
 
-        // stg_orders has no inputs and 1 output (fct_orders, its child)
-        // fct_orders has 1 input (stg_orders) and no outputs (leaf node)
-        var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.fct_orders");
+        // Each model emits itself as its own output; model-to-model edges are the downstream
+        // model's inputs. stg_orders has no inputs, fct_orders has 1 input (stg_orders).
+        var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.staging.stg_orders");
         assertThat("stg_orders emission should exist", stgOrdersEmit, is(notNullValue()));
         assertThat(stgOrdersEmit.inputs(), hasSize(0));
         assertThat(stgOrdersEmit.outputs(), hasSize(1));
 
-        var fctOrdersOutput = stgOrdersEmit.outputs().getFirst();
-        assertThat(fctOrdersOutput.getMetadata().get("system"), is("postgres"));
-        assertThat(fctOrdersOutput.getMetadata().get("database"), is("analytics"));
-        assertThat(fctOrdersOutput.getMetadata().get("schema"), is("marts"));
-        assertThat(fctOrdersOutput.getMetadata().get("name"), is("fct_orders"));
+        var stgOrdersOutput = stgOrdersEmit.outputs().getFirst();
+        assertThat(stgOrdersOutput.getMetadata().get("system"), is("postgres"));
+        assertThat(stgOrdersOutput.getMetadata().get("database"), is("analytics"));
+        assertThat(stgOrdersOutput.getMetadata().get("schema"), is("staging"));
+        assertThat(stgOrdersOutput.getMetadata().get("name"), is("stg_orders"));
 
-        var fctOrdersEmit = findEmitWithInput(runContext.assets().emitted(), "analytics.staging.stg_orders");
+        var fctOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.fct_orders");
         assertThat("fct_orders emission should exist", fctOrdersEmit, is(notNullValue()));
         assertThat(fctOrdersEmit.inputs(), hasSize(1));
-        assertThat(fctOrdersEmit.outputs(), hasSize(0));
+        assertThat(fctOrdersEmit.inputs().getFirst().id(), is("analytics.staging.stg_orders"));
+        assertThat(fctOrdersEmit.outputs(), hasSize(1));
+        assertThat(fctOrdersEmit.outputs().getFirst().getId(), is("analytics.marts.fct_orders"));
     }
 
     @Test
@@ -150,18 +152,58 @@ class ResultParserTest {
 
         assertThat(runContext.assets().emitted(), hasSize(2));
 
-        // my_first_dbt_model: no inputs, 1 output (my_second_dbt_model)
-        var firstModelEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.my_second_dbt_model");
+        // Each model emits itself as its own output; edges are expressed as the downstream model's inputs.
+        // my_first_dbt_model: no inputs
+        var firstModelEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.my_first_dbt_model");
         assertThat(firstModelEmit, is(notNullValue()));
         assertThat(firstModelEmit.inputs(), hasSize(0));
-        assertThat(firstModelEmit.outputs(), hasSize(1));
 
-        // my_second_dbt_model: 1 input (my_first_dbt_model), no outputs (leaf)
-        var secondModelEmit = findEmitWithInput(runContext.assets().emitted(), "analytics.marts.my_first_dbt_model");
+        // my_second_dbt_model: 1 input (my_first_dbt_model)
+        var secondModelEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.my_second_dbt_model");
         assertThat(secondModelEmit, is(notNullValue()));
         assertThat(secondModelEmit.inputs(), hasSize(1));
         assertThat(secondModelEmit.inputs().getFirst().id(), is("analytics.marts.my_first_dbt_model"));
-        assertThat(secondModelEmit.outputs(), hasSize(0));
+    }
+
+    @Test
+    void parseManifestWithAssets_singleModelWithOnlySourceDependency_shouldEmitModelAsOutput() throws Exception {
+        // A single-model project (or any model whose only dependency is a dbt source, not another
+        // model) has no model-to-model edge. It must still surface as its own output asset instead
+        // of emitting nothing (regression for a single model / source-only model producing no asset).
+        var runContext = mockRunContext();
+        var manifestFile = runContext.workingDir().path(true).resolve("manifest.json");
+        Files.writeString(manifestFile, """
+            {
+              "metadata": {
+                "adapter_type": "duckdb"
+              },
+              "nodes": {
+                "model.analytics.stg_orders": {
+                  "resource_type": "model",
+                  "database": "analytics",
+                  "schema": "staging",
+                  "name": "stg_orders",
+                  "unique_id": "model.analytics.stg_orders",
+                  "depends_on": {
+                    "nodes": ["source.analytics.raw.orders"]
+                  }
+                }
+              },
+              "parent_map": {
+                "model.analytics.stg_orders": ["source.analytics.raw.orders"]
+              }
+            }
+            """);
+
+        ResultParser.parseManifestWithAssets(runContext, manifestFile.toFile());
+
+        assertThat(runContext.assets().emitted(), hasSize(1));
+
+        var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.staging.stg_orders");
+        assertThat("stg_orders should be emitted as its own output asset", stgOrdersEmit, is(notNullValue()));
+        assertThat(stgOrdersEmit.inputs(), hasSize(0));
+        assertThat(stgOrdersEmit.outputs(), hasSize(1));
+        assertThat(stgOrdersEmit.outputs().getFirst().getId(), is("analytics.staging.stg_orders"));
     }
 
     @Test
@@ -220,31 +262,24 @@ class ResultParserTest {
         assertThat(runContext.assets().emitted(), hasSize(3));
 
         // DAG: stg_orders → int_orders → fct_orders (parent_map, no transitive edges)
-        // Inputs = upstream deps, Outputs = downstream children
+        // Each model emits itself as its own output; inputs are its upstream model dependencies.
 
-        // stg_orders: no model inputs (source filtered out), 1 output (int_orders)
-        var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "dev.intermediate.int_orders");
+        // stg_orders: no model inputs (source filtered out)
+        var stgOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "dev.staging.stg_orders");
         assertThat(stgOrdersEmit, is(notNullValue()));
         assertThat(stgOrdersEmit.inputs(), hasSize(0));
-        assertThat(stgOrdersEmit.outputs(), hasSize(1));
 
-        // int_orders: 1 input (stg_orders), 1 output (fct_orders)
-        var intOrdersEmit = findEmitWithInputAndOutput(
-            runContext.assets().emitted(),
-            "dev.staging.stg_orders", "dev.marts.fct_orders"
-        );
+        // int_orders: 1 input (stg_orders)
+        var intOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "dev.intermediate.int_orders");
         assertThat(intOrdersEmit, is(notNullValue()));
         assertThat(intOrdersEmit.inputs(), hasSize(1));
         assertThat(intOrdersEmit.inputs().getFirst().id(), is("dev.staging.stg_orders"));
-        assertThat(intOrdersEmit.outputs(), hasSize(1));
-        assertThat(intOrdersEmit.outputs().getFirst().getId(), is("dev.marts.fct_orders"));
 
-        // fct_orders: 1 input (int_orders only, from parent_map), no outputs (leaf)
-        var fctOrdersEmit = findEmitWithInput(runContext.assets().emitted(), "dev.intermediate.int_orders");
+        // fct_orders: 1 input (int_orders only, from parent_map)
+        var fctOrdersEmit = findEmitWithOutput(runContext.assets().emitted(), "dev.marts.fct_orders");
         assertThat(fctOrdersEmit, is(notNullValue()));
         assertThat(fctOrdersEmit.inputs(), hasSize(1));
         assertThat(fctOrdersEmit.inputs().getFirst().id(), is("dev.intermediate.int_orders"));
-        assertThat(fctOrdersEmit.outputs(), hasSize(0));
     }
 
     @Test
@@ -335,22 +370,6 @@ class ResultParserTest {
 
     private static AssetEmit findEmitWithOutput(List<AssetEmit> emitted, String outputId) {
         return emitted.stream()
-            .filter(e -> e.outputs().stream().anyMatch(o -> o.getId().equals(outputId)))
-            .findFirst()
-            .orElse(null);
-    }
-
-    private static AssetEmit findEmitWithInput(List<AssetEmit> emitted, String inputId) {
-        return emitted.stream()
-            .filter(e -> e.inputs().stream().anyMatch(i -> i.id().equals(inputId)))
-            .filter(e -> e.outputs().isEmpty())
-            .findFirst()
-            .orElse(null);
-    }
-
-    private static AssetEmit findEmitWithInputAndOutput(List<AssetEmit> emitted, String inputId, String outputId) {
-        return emitted.stream()
-            .filter(e -> e.inputs().stream().anyMatch(i -> i.id().equals(inputId)))
             .filter(e -> e.outputs().stream().anyMatch(o -> o.getId().equals(outputId)))
             .findFirst()
             .orElse(null);

--- a/src/test/java/io/kestra/plugin/dbt/cli/RunnerTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cli/RunnerTest.java
@@ -48,62 +48,62 @@ class RunnerTest {
         assertThat("should emit exactly 8 model assets", allEmitted, hasSize(8));
 
         /*
-         * Expected lineage (inputs = upstream deps, outputs = downstream children):
+         * Expected lineage (each model emits itself as output; inputs = upstream deps):
          *
-         * stg_customers: inputs=[] outputs=[int_customer_orders]
-         * stg_orders: inputs=[] outputs=[int_customer_orders, int_order_payments, int_daily_revenue]
-         * stg_payments: inputs=[] outputs=[int_order_payments, int_daily_revenue]
-         * int_customer_orders: inputs=[stg_customers, stg_orders] outputs=[fct_customer_summary]
-         * int_order_payments: inputs=[stg_orders, stg_payments] outputs=[fct_customer_summary]
-         * int_daily_revenue: inputs=[stg_orders, stg_payments] outputs=[fct_revenue_by_customer]
-         * fct_customer_summary: inputs=[int_customer_orders, int_order_payments] outputs=[fct_revenue_by_customer]
-         * fct_revenue_by_customer: inputs=[fct_customer_summary, int_daily_revenue] outputs=[]
+         * stg_customers: inputs=[] outputs=[stg_customers]
+         * stg_orders: inputs=[] outputs=[stg_orders]
+         * stg_payments: inputs=[] outputs=[stg_payments]
+         * int_customer_orders: inputs=[stg_customers, stg_orders] outputs=[int_customer_orders]
+         * int_order_payments: inputs=[stg_orders, stg_payments] outputs=[int_order_payments]
+         * int_daily_revenue: inputs=[stg_orders, stg_payments] outputs=[int_daily_revenue]
+         * fct_customer_summary: inputs=[int_customer_orders, int_order_payments] outputs=[fct_customer_summary]
+         * fct_revenue_by_customer: inputs=[fct_customer_summary, int_daily_revenue] outputs=[fct_revenue_by_customer]
          */
 
-        // Staging models: no inputs, outputs are the intermediate models they feed
+        // Staging models: no inputs, output is the model itself
         assertEmission(
             allEmitted, "stg_customers",
             List.of(),
-            List.of("memory.main.int_customer_orders")
+            List.of("memory.main.stg_customers")
         );
         assertEmission(
             allEmitted, "stg_orders",
             List.of(),
-            List.of("memory.main.int_customer_orders", "memory.main.int_order_payments", "memory.main.int_daily_revenue")
+            List.of("memory.main.stg_orders")
         );
         assertEmission(
             allEmitted, "stg_payments",
             List.of(),
-            List.of("memory.main.int_order_payments", "memory.main.int_daily_revenue")
+            List.of("memory.main.stg_payments")
         );
 
-        // Intermediate models: inputs from staging, outputs to marts
+        // Intermediate models: inputs from staging, output is the model itself
         assertEmission(
             allEmitted, "int_customer_orders",
             List.of("memory.main.stg_customers", "memory.main.stg_orders"),
-            List.of("memory.main.fct_customer_summary")
+            List.of("memory.main.int_customer_orders")
         );
         assertEmission(
             allEmitted, "int_order_payments",
             List.of("memory.main.stg_orders", "memory.main.stg_payments"),
-            List.of("memory.main.fct_customer_summary")
+            List.of("memory.main.int_order_payments")
         );
         assertEmission(
             allEmitted, "int_daily_revenue",
             List.of("memory.main.stg_orders", "memory.main.stg_payments"),
-            List.of("memory.main.fct_revenue_by_customer")
+            List.of("memory.main.int_daily_revenue")
         );
 
         // Mart models
         assertEmission(
             allEmitted, "fct_customer_summary",
             List.of("memory.main.int_customer_orders", "memory.main.int_order_payments"),
-            List.of("memory.main.fct_revenue_by_customer")
+            List.of("memory.main.fct_customer_summary")
         );
         assertEmission(
             allEmitted, "fct_revenue_by_customer",
             List.of("memory.main.fct_customer_summary", "memory.main.int_daily_revenue"),
-            List.of()
+            List.of("memory.main.fct_revenue_by_customer")
         );
     }
 


### PR DESCRIPTION
## What

`DbtCLI` with `assets.enableAuto: true` derives dbt assets from `manifest.json` for the EE asset/lineage catalog. The derivation only emitted model-to-model lineage **edges** and never emitted a dbt model as its own asset. As a result, a model with no model-to-model dependency emitted an empty `AssetEmit([], [])` and produced no asset node, even though the run succeeded and logged `dbt assets extracted from manifest: 1`.

Affected shapes:
- a single-model project,
- a model reading only from a dbt `source` (no upstream model),
- a terminal model (nothing downstream),
- a DAG root model (children but no parent was also never emitted as its own node),
- fan-in children were emitted twice (once per parent).

Confirmed live on an EE instance: a single Snowflake model showed nothing in the Assets tab, while the multi-model `kestra-io/dbt-example` (which `ref()`s between models) worked, because only that shape exercises the edge path.

## How

In `ResultParser`, both emission paths now emit each model as its **own output asset**:
- `emitAssets(...)` (flow-level, feeds `runContext.assets().emit`)
- `assetsFor(...)` (per dbt-model dynamic taskrun, feeds `AssetsInOut`)

Each model emits `outputs = [the model itself]` (a `Custom` asset with its `database.schema.name` id). Model-to-model edges are preserved because they are already expressed as the downstream model's `inputs` (unchanged `inputIdentifiers`). Removed the now-dead `outputAssets(...)` and the reverse-dependency (`children`) computation.

Result: every dbt model surfaces as an asset node regardless of DAG shape, edges intact, no double-emit on fan-in.

Note: `source` dependencies are still not emitted as inputs (unchanged behavior). That is a separate follow-up.

## Tests

- New regression test for the single-model / source-only-dependency shape (fails on the old code, passes now).
- Updated existing asset tests and the 8-model `RunnerTest.complexDagLineage` end-to-end check to the new semantics.
- Full suite green.
