### PR TITLE
fix(dbt): adopt an already-created run when the trigger POST response is lost

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -19,12 +19,12 @@ import io.kestra.core.http.client.HttpClientException;
 import io.kestra.core.http.client.HttpClientRequestException;
 import io.kestra.core.http.client.HttpClientResponseException;
 import io.kestra.core.http.client.configurations.HttpConfiguration;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.retrys.Exponential;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.RetryUtils;
-import io.kestra.core.models.annotations.PluginProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -120,7 +120,8 @@ public abstract class AbstractDbtCloud extends Task {
     /**
      * Whether an error calling the dbt Cloud API is transient and worth retrying.
      *
-     * <p>Read-only methods (GET/HEAD) retry any transient signal: all 5xx, connection failures and
+     * <p>
+     * Read-only methods (GET/HEAD) retry any transient signal: all 5xx, connection failures and
      * timeouts. Other methods retry only the 502/503/504 gateway errors plus transport failures that
      * provably never reached dbt Cloud (TLS handshake, connection refused). A plain 500, a read timeout
      * or a mid-flight connection drop is not retried for them, since the request may already have
@@ -129,7 +130,8 @@ public abstract class AbstractDbtCloud extends Task {
      * any method, since dbt Cloud rejects it before running the request. Other client errors (4xx) are
      * never retried.
      *
-     * <p>The core HTTP client wraps a read timeout as {@code RuntimeException(SocketTimeoutException)},
+     * <p>
+     * The core HTTP client wraps a read timeout as {@code RuntimeException(SocketTimeoutException)},
      * so it is matched through the cause.
      */
     static boolean isRetriableTransientError(Throwable throwable, String method) {
@@ -174,6 +176,35 @@ public abstract class AbstractDbtCloud extends Task {
     // not safe to retry blindly here, so they are treated as write methods.
     private static boolean isReadOnlyMethod(String method) {
         return "GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method);
+    }
+
+    /**
+     * Whether a failed write call may already have reached dbt Cloud and created the run, as opposed
+     * to one that either never left the client or definitely did reach it (with a response already
+     * received). Used by callers that need to decide whether it is safe to look up and adopt the run
+     * that call may have created, instead of failing outright.
+     *
+     * <p>
+     * Mirrors the positive reasoning in {@link #isRetriableTransientError}: only a read timeout or a
+     * mid-flight connection drop leaves the request's fate genuinely unknown. A definitive HTTP
+     * response (any status code, including 4xx/5xx) means dbt Cloud received the request and replied,
+     * so it is never ambiguous. A TLS handshake failure or a refused connection provably never left
+     * the client either, so those are excluded even though they surface as an {@link IOException}.
+     */
+    static boolean wasPossiblySent(Throwable throwable) {
+        if (throwable == null) {
+            return false;
+        }
+
+        if (throwable instanceof HttpClientResponseException) {
+            return false;
+        }
+
+        if (hasCause(throwable, SSLHandshakeException.class) || hasCause(throwable, ConnectException.class)) {
+            return false;
+        }
+
+        return hasCause(throwable, SocketTimeoutException.class) || hasCause(throwable, IOException.class);
     }
 
     // Walks the cause chain (bounded, to tolerate a cyclic cause) looking for a given exception type.

--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -120,11 +120,16 @@ public abstract class AbstractDbtCloud extends Task {
                 () ->
                 {
                     var response = client.request(request, String.class);
-                    // A response with no body cannot be parsed. Surface it as a null-bodied response so the
-                    // caller's own "missing body" handling runs, instead of an opaque Jackson null-argument
-                    // error (readValue(null, ...) throws IllegalArgumentException, not an IOException).
+                    // A success status with an empty body cannot be parsed. Throw rather than return a
+                    // null-bodied response: callers that expect a body (e.g. artifact download) fail loudly
+                    // instead of silently writing a "null" artifact, and the trigger POST sees an IOException,
+                    // which isAmbiguousFailure treats as ambiguous so it confirms the run it may have created.
+                    // readValue(null, ...) would itself throw an opaque IllegalArgumentException, so guard first.
                     var body = response.getBody();
-                    var parsedResponse = body == null ? null : MAPPER.readValue(body, responseType);
+                    if (body == null || body.isBlank()) {
+                        throw new IOException("Empty response body from dbt Cloud");
+                    }
+                    var parsedResponse = MAPPER.readValue(body, responseType);
                     return HttpResponse.<RES> builder()
                         .request(request)
                         .body(parsedResponse)

--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -179,21 +179,11 @@ public abstract class AbstractDbtCloud extends Task {
     }
 
     /**
-     * Whether a failed write call may already have reached dbt Cloud and created the run, as opposed
-     * to one that either never left the client or definitely did reach it (with a response already
-     * received). Used by callers that need to decide whether it is safe to look up and adopt the run
-     * that call may have created, instead of failing outright.
-     *
-     * <p>
-     * Mirrors the positive reasoning in {@link #isRetriableTransientError}: only a read timeout or a
-     * mid-flight connection drop leaves the request's fate genuinely unknown, so those are the cases
-     * this returns true for. A definitive HTTP response (any status code, including 4xx/5xx) is treated
-     * as unambiguous and returns false. This is not an absolute guarantee: if a 200 response body fails
-     * Jackson deserialization, that surfaces here as a plain {@link IOException} indistinguishable from
-     * a timeout, so this returns true even though a response was in fact received. That misclassification
-     * is harmless, since the run really was created and adopting it is still the correct outcome. A TLS
-     * handshake failure or a refused connection provably never left the client, so those are excluded
-     * even though they too surface as an {@link IOException}.
+     * Whether a failed write call may already have reached dbt Cloud and created the run, so callers can
+     * decide whether to look it up and adopt it rather than fail. True only for a read timeout or a
+     * mid-flight drop, whose fate is unknown. A received HTTP response, a TLS handshake failure, or a
+     * refused connection all return false. A 200 whose body fails to parse also returns true (it looks
+     * like an {@link IOException}), which is harmless since the run really was created.
      */
     static boolean wasPossiblySent(Throwable throwable) {
         if (throwable == null) {

--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -120,7 +120,11 @@ public abstract class AbstractDbtCloud extends Task {
                 () ->
                 {
                     var response = client.request(request, String.class);
-                    var parsedResponse = MAPPER.readValue(response.getBody(), responseType);
+                    // A response with no body cannot be parsed. Surface it as a null-bodied response so the
+                    // caller's own "missing body" handling runs, instead of an opaque Jackson null-argument
+                    // error (readValue(null, ...) throws IllegalArgumentException, not an IOException).
+                    var body = response.getBody();
+                    var parsedResponse = body == null ? null : MAPPER.readValue(body, responseType);
                     return HttpResponse.<RES> builder()
                         .request(request)
                         .body(parsedResponse)

--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -186,10 +186,14 @@ public abstract class AbstractDbtCloud extends Task {
      *
      * <p>
      * Mirrors the positive reasoning in {@link #isRetriableTransientError}: only a read timeout or a
-     * mid-flight connection drop leaves the request's fate genuinely unknown. A definitive HTTP
-     * response (any status code, including 4xx/5xx) means dbt Cloud received the request and replied,
-     * so it is never ambiguous. A TLS handshake failure or a refused connection provably never left
-     * the client either, so those are excluded even though they surface as an {@link IOException}.
+     * mid-flight connection drop leaves the request's fate genuinely unknown, so those are the cases
+     * this returns true for. A definitive HTTP response (any status code, including 4xx/5xx) is treated
+     * as unambiguous and returns false. This is not an absolute guarantee: if a 200 response body fails
+     * Jackson deserialization, that surfaces here as a plain {@link IOException} indistinguishable from
+     * a timeout, so this returns true even though a response was in fact received. That misclassification
+     * is harmless, since the run really was created and adopting it is still the correct outcome. A TLS
+     * handshake failure or a refused connection provably never left the client, so those are excluded
+     * even though they too surface as an {@link IOException}.
      */
     static boolean wasPossiblySent(Throwable throwable) {
         if (throwable == null) {

--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -6,6 +6,8 @@ import java.net.NoRouteToHostException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.util.Set;
+import java.util.function.BiPredicate;
 
 import javax.net.ssl.SSLHandshakeException;
 
@@ -85,6 +87,17 @@ public abstract class AbstractDbtCloud extends Task {
         RunContext runContext,
         HttpRequest.HttpRequestBuilder requestBuilder,
         Class<RES> responseType) throws HttpClientException, IllegalVariableEvaluationException, IOException {
+        return this.request(runContext, requestBuilder, responseType, AbstractDbtCloud::isRetriableTransientError);
+    }
+
+    // Same as above but with a caller-supplied retry decision (throwable, method) -> retry. Used by callers
+    // that can recover an ambiguous write differently (e.g. TriggerRun confirming and adopting the run it may
+    // already have created) and so must not let the generic retry re-send it.
+    protected <RES> HttpResponse<RES> request(
+        RunContext runContext,
+        HttpRequest.HttpRequestBuilder requestBuilder,
+        Class<RES> responseType,
+        BiPredicate<Throwable, String> retryWhen) throws HttpClientException, IllegalVariableEvaluationException, IOException {
 
         var request = requestBuilder
             .addHeader("Authorization", "Bearer " + runContext.render(this.token).as(String.class).orElseThrow())
@@ -103,7 +116,7 @@ public abstract class AbstractDbtCloud extends Task {
                     .maxAttempts(rMaxRetries)
                     .build()
             ).run(
-                (res, throwable) -> isRetriableTransientError(throwable, request.getMethod()),
+                (res, throwable) -> retryWhen.test(throwable, request.getMethod()),
                 () ->
                 {
                     var response = client.request(request, String.class);
@@ -118,6 +131,18 @@ public abstract class AbstractDbtCloud extends Task {
             );
         }
     }
+
+    // dbt Cloud rejects a rate-limited request before running it, so it is always safe to retry.
+    private static final int TOO_MANY_REQUESTS = 429;
+
+    // Gateway errors retried for a write. 503 almost certainly never reached the app. 502 and 504 are
+    // ambiguous (the request may already have created the run), so a caller that can look the run up
+    // routes them through isAmbiguousFailure instead, but the generic retry keeps them for callers that
+    // cannot, preserving the previous behavior.
+    private static final Set<Integer> RETRIABLE_WRITE_GATEWAY_CODES = Set.of(502, 503, 504);
+
+    // Gateway errors that may mean dbt Cloud already received the write and created the run.
+    private static final Set<Integer> AMBIGUOUS_WRITE_GATEWAY_CODES = Set.of(502, 504);
 
     /**
      * Whether an error calling the dbt Cloud API is transient and worth retrying.
@@ -145,14 +170,13 @@ public abstract class AbstractDbtCloud extends Task {
 
         if (throwable instanceof HttpClientResponseException ex) {
             int code = ex.getResponse().getStatus().getCode();
-            // 429 (rate limited) is rejected before the request runs, so it is safe to retry for any method.
-            if (code == 429) {
+            if (code == TOO_MANY_REQUESTS) {
                 return true;
             }
             if (readOnly) {
                 return code >= 500 && code <= 599;
             }
-            return code == 502 || code == 503 || code == 504;
+            return RETRIABLE_WRITE_GATEWAY_CODES.contains(code);
         }
 
         // Transport-level failures. For read-only methods any of them is retriable. For write methods
@@ -182,21 +206,24 @@ public abstract class AbstractDbtCloud extends Task {
 
     /**
      * Whether a failed write call had an ambiguous outcome: it may already have reached dbt Cloud and
-     * created the run, so callers can look it up and adopt it rather than fail. True only for a read
-     * timeout or a mid-flight drop, whose fate is unknown. A received HTTP response, a TLS handshake
-     * failure, a refused connection, a DNS resolution failure, or a no-route-to-host error all return
-     * false: none of these ever put a byte on the wire. A generic {@link java.net.SocketException} (e.g.
-     * a connection reset mid-flight) is deliberately NOT excluded, since the request may already have
-     * reached dbt Cloud. A 200 whose body fails to parse also returns true (it looks like an
-     * {@link IOException}), which is harmless since the run really was created.
+     * created the run, so callers can look it up and adopt it rather than fail. True for a read timeout,
+     * a mid-flight drop, or a 502/504 gateway error, whose fate is unknown. Any other HTTP response
+     * (a 4xx, a plain 500, a 503) is a definitive answer and returns false, as do a TLS handshake
+     * failure, a refused connection, a DNS resolution failure, and a no-route-to-host error, since none
+     * of these ever put a byte on the wire. A generic {@link java.net.SocketException} (e.g. a connection
+     * reset mid-flight) is deliberately NOT excluded, since the request may already have reached dbt
+     * Cloud. A 200 whose body fails to parse also returns true (it looks like an {@link IOException}),
+     * which is harmless since the run really was created.
      */
     static boolean isAmbiguousFailure(Throwable throwable) {
         if (throwable == null) {
             return false;
         }
 
-        if (throwable instanceof HttpClientResponseException) {
-            return false;
+        if (throwable instanceof HttpClientResponseException ex) {
+            // A 502/504 gateway error may mean dbt Cloud received the request behind the proxy; any other
+            // response is a definitive answer, so it is not ambiguous.
+            return AMBIGUOUS_WRITE_GATEWAY_CODES.contains(ex.getResponse().getStatus().getCode());
         }
 
         if (

--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -181,16 +181,16 @@ public abstract class AbstractDbtCloud extends Task {
     }
 
     /**
-     * Whether a failed write call may already have reached dbt Cloud and created the run, so callers can
-     * decide whether to look it up and adopt it rather than fail. True only for a read timeout or a
-     * mid-flight drop, whose fate is unknown. A received HTTP response, a TLS handshake failure, a
-     * refused connection, a DNS resolution failure, or a no-route-to-host error all return false: none of
-     * these ever put a byte on the wire. A generic {@link java.net.SocketException} (e.g. a connection
-     * reset mid-flight) is deliberately NOT excluded, since the request may already have reached dbt
-     * Cloud. A 200 whose body fails to parse also returns true (it looks like an {@link IOException}),
-     * which is harmless since the run really was created.
+     * Whether a failed write call had an ambiguous outcome: it may already have reached dbt Cloud and
+     * created the run, so callers can look it up and adopt it rather than fail. True only for a read
+     * timeout or a mid-flight drop, whose fate is unknown. A received HTTP response, a TLS handshake
+     * failure, a refused connection, a DNS resolution failure, or a no-route-to-host error all return
+     * false: none of these ever put a byte on the wire. A generic {@link java.net.SocketException} (e.g.
+     * a connection reset mid-flight) is deliberately NOT excluded, since the request may already have
+     * reached dbt Cloud. A 200 whose body fails to parse also returns true (it looks like an
+     * {@link IOException}), which is harmless since the run really was created.
      */
-    static boolean wasPossiblySent(Throwable throwable) {
+    static boolean isAmbiguousFailure(Throwable throwable) {
         if (throwable == null) {
             return false;
         }

--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -2,7 +2,9 @@ package io.kestra.plugin.dbt.cloud;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.NoRouteToHostException;
 import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.time.Duration;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -181,9 +183,12 @@ public abstract class AbstractDbtCloud extends Task {
     /**
      * Whether a failed write call may already have reached dbt Cloud and created the run, so callers can
      * decide whether to look it up and adopt it rather than fail. True only for a read timeout or a
-     * mid-flight drop, whose fate is unknown. A received HTTP response, a TLS handshake failure, or a
-     * refused connection all return false. A 200 whose body fails to parse also returns true (it looks
-     * like an {@link IOException}), which is harmless since the run really was created.
+     * mid-flight drop, whose fate is unknown. A received HTTP response, a TLS handshake failure, a
+     * refused connection, a DNS resolution failure, or a no-route-to-host error all return false: none of
+     * these ever put a byte on the wire. A generic {@link java.net.SocketException} (e.g. a connection
+     * reset mid-flight) is deliberately NOT excluded, since the request may already have reached dbt
+     * Cloud. A 200 whose body fails to parse also returns true (it looks like an {@link IOException}),
+     * which is harmless since the run really was created.
      */
     static boolean wasPossiblySent(Throwable throwable) {
         if (throwable == null) {
@@ -194,7 +199,12 @@ public abstract class AbstractDbtCloud extends Task {
             return false;
         }
 
-        if (hasCause(throwable, SSLHandshakeException.class) || hasCause(throwable, ConnectException.class)) {
+        if (
+            hasCause(throwable, SSLHandshakeException.class)
+                || hasCause(throwable, ConnectException.class)
+                || hasCause(throwable, UnknownHostException.class)
+                || hasCause(throwable, NoRouteToHostException.class)
+        ) {
             return false;
         }
 

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -17,7 +17,9 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.retrys.Constant;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.RetryUtils;
 import io.kestra.plugin.dbt.cloud.models.JobStatus;
 import io.kestra.plugin.dbt.cloud.models.Run;
 import io.kestra.plugin.dbt.cloud.models.RunListResponse;
@@ -61,9 +63,9 @@ import lombok.experimental.SuperBuilder;
 )
 public class TriggerRun extends AbstractDbtCloud implements RunnableTask<TriggerRun.Output> {
 
-    // A just-created run can take a moment to show up in the run list.
+    // A just-created run can take a moment to show up in the run list, so the confirm lookup is retried.
     private static final int CONFIRM_LOOKUP_MAX_ATTEMPTS = 3;
-    private static final Duration CONFIRM_LOOKUP_BACKOFF = Duration.ofSeconds(1);
+    private static final Duration CONFIRM_LOOKUP_BACKOFF = Duration.ofSeconds(2);
 
     @Schema(
         title = "Job ID",
@@ -243,7 +245,7 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
             triggerResponse = this.request(runContext, requestBuilder, RunResponse.class);
         } catch (Exception e) {
             // An ambiguous failure may mean dbt already created the run, so confirm before failing.
-            if (reattachEnabled && wasPossiblySent(e)) {
+            if (reattachEnabled && isAmbiguousFailure(e)) {
                 Run adoptedRun = null;
                 try {
                     adoptedRun = this.confirmRunAfterAmbiguousFailure(runContext, baseline);
@@ -329,29 +331,24 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     }
 
     /**
-     * After an ambiguous trigger failure, check whether the run was created, retrying a few times since
-     * a just-created run can take a moment to appear in the run list. Only a run whose id is strictly
-     * greater than {@code baseline} is accepted: the tag in the run cause is reused across retries of the
-     * same taskrun, so the newest tagged run at this point could still be a stale run from a prior
-     * attempt (id == baseline) rather than the one this attempt's POST just created.
+     * After an ambiguous trigger failure, check whether the run was created, retrying the lookup a few
+     * times since a just-created run can take a moment to appear in the run list. Only a run whose id is
+     * strictly greater than {@code baseline} is accepted: the tag in the run cause is reused across
+     * retries of the same taskrun, so the newest tagged run could still be a stale run from a prior
+     * attempt (id == baseline) rather than the one this attempt's POST just created. Throws once the
+     * attempts are exhausted without such a run, which the caller treats as "not created".
      */
     private Run confirmRunAfterAmbiguousFailure(RunContext runContext, long baseline) throws Exception {
-        for (int attempt = 1; attempt <= CONFIRM_LOOKUP_MAX_ATTEMPTS; attempt++) {
-            var found = this.findRunForThisTaskRun(runContext);
-            if (found != null && found.getId() != null && found.getId() > baseline) {
-                return found;
-            }
-            if (attempt < CONFIRM_LOOKUP_MAX_ATTEMPTS) {
-                try {
-                    Thread.sleep(CONFIRM_LOOKUP_BACKOFF.toMillis());
-                } catch (InterruptedException ie) {
-                    // Stop looking; let the caller rethrow the original trigger failure.
-                    Thread.currentThread().interrupt();
-                    return null;
-                }
-            }
-        }
-        return null;
+        return RetryUtils.<Run, Exception> of(
+            Constant.builder()
+                .interval(CONFIRM_LOOKUP_BACKOFF)
+                .maxAttempts(CONFIRM_LOOKUP_MAX_ATTEMPTS)
+                .build()
+        )
+            .run(
+                (run, throwable) -> throwable == null && (run == null || run.getId() == null || run.getId() <= baseline),
+                () -> this.findRunForThisTaskRun(runContext)
+            );
     }
 
     /** The marker embedded in a run's cause so a reattach can identify the run this taskrun started. */

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -60,6 +60,11 @@ import lombok.experimental.SuperBuilder;
 )
 public class TriggerRun extends AbstractDbtCloud implements RunnableTask<TriggerRun.Output> {
 
+    // Bounded retry for the post-failure confirm-and-adopt lookup: a run that was just created by an
+    // ambiguous (possibly-sent) trigger call can take a moment to show up in the run list.
+    private static final int CONFIRM_LOOKUP_MAX_ATTEMPTS = 3;
+    private static final Duration CONFIRM_LOOKUP_BACKOFF = Duration.ofSeconds(1);
+
     @Schema(
         title = "Job ID",
         description = "Numeric dbt Cloud job identifier to trigger."
@@ -139,9 +144,11 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     @Schema(
         title = "Reattach to an in-flight run",
         description = """
-            If true, on a worker restart or retry the task reattaches to the run it already started and waits for it \
-            instead of triggering a duplicate. It only reattaches to a run this execution started (matched by the \
-            taskrun id in the run cause), never one triggered elsewhere. Default false, which always triggers a new run."""
+            If true, the task reattaches to a run it already started instead of triggering a duplicate: at the \
+            start of a worker restart or retry, and when the trigger call itself fails with an ambiguous error \
+            (e.g. a timeout) that may mean dbt Cloud already received it. It only reattaches to a run this \
+            execution started (matched by the taskrun id in the run cause), never one triggered elsewhere. \
+            Default false, which always triggers a new run."""
     )
     @Builder.Default
     @PluginProperty(group = "reliability")
@@ -176,13 +183,13 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
         boolean reattachEnabled = Boolean.TRUE.equals(runContext.render(this.reattach).as(Boolean.class).orElse(Boolean.FALSE));
 
         if (reattachEnabled) {
-            Run inFlightRun = this.findInFlightRun(runContext);
-            if (inFlightRun != null) {
+            Run existingRun = this.findRunForThisTaskRun(runContext);
+            if (existingRun != null) {
                 logger.info(
-                    "Reattached to in-flight run {} (status {}) instead of triggering a new one",
-                    inFlightRun.getId(), inFlightRun.getStatus()
+                    "Reattached to run {} (status {}) already started by this taskrun instead of triggering a new one",
+                    existingRun.getId(), existingRun.getStatus()
                 );
-                return this.waitOrReturn(runContext, inFlightRun.getId());
+                return this.waitOrReturn(runContext, existingRun.getId());
             }
         }
 
@@ -223,7 +230,33 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
                     .build()
             );
 
-        HttpResponse<RunResponse> triggerResponse = this.request(runContext, requestBuilder, RunResponse.class);
+        HttpResponse<RunResponse> triggerResponse;
+        try {
+            triggerResponse = this.request(runContext, requestBuilder, RunResponse.class);
+        } catch (Exception e) {
+            // Only when reattach is on (a marker was written above) is a lookup reliable: an ambiguous
+            // failure (read timeout, mid-flight drop) may mean dbt Cloud already created the run, so
+            // confirm before failing loud and creating a duplicate on the next retry.
+            if (reattachEnabled && wasPossiblySent(e)) {
+                Run adoptedRun = null;
+                try {
+                    adoptedRun = this.confirmRunAfterAmbiguousFailure(runContext);
+                } catch (Exception confirmEx) {
+                    // The confirm-lookup itself failing (the GET exhausting retries, an interrupted
+                    // backoff) must never mask the original trigger failure below: log and fall
+                    // through so `e` is the one rethrown.
+                    logger.warn("Could not confirm whether the ambiguous trigger call created a run: {}", confirmEx.getMessage());
+                }
+                if (adoptedRun != null) {
+                    logger.warn(
+                        "Trigger call failed ({}) but dbt Cloud already has a matching run {} (status {}); adopting it instead of failing",
+                        e.getMessage(), adoptedRun.getId(), adoptedRun.getStatus()
+                    );
+                    return this.waitOrReturn(runContext, adoptedRun.getId());
+                }
+            }
+            throw e;
+        }
 
         RunResponse triggerRunResponse = triggerResponse.getBody();
         if (triggerRunResponse == null) {
@@ -235,19 +268,33 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
         return this.waitOrReturn(runContext, triggerRunResponse.getData().getId());
     }
 
+    // Bounds the run-list lookup below to the most recent runs of the job. `order_by=-id` puts the
+    // newest run first, so the tagged run is only missed if more than this many newer runs of the
+    // same job were created since it started: a residual limitation, documented on the method itself.
+    private static final int FIND_RUN_LOOKUP_LIMIT = 100;
+
     /**
-     * Look for an in-flight run of the job (Queued, Starting, or Running) that this taskrun started,
-     * matched by the taskrun tag in the run cause. Returns null when there is none, in which case a
+     * Look for a run of the job that this taskrun already started, matched strictly by the taskrun
+     * tag in the run cause: that tag is the unique key, so any status (queued, running, or already
+     * finished) qualifies. A finished run must be adopted and its real outcome reported by
+     * {@link #waitOrReturn}, never re-triggered. Returns null when there is none, in which case a
      * fresh run is triggered rather than attaching to a run this execution did not start.
+     *
+     * <p>
+     * The lookup is bounded to the {@value #FIND_RUN_LOOKUP_LIMIT} most recent runs of the job
+     * (newest first via {@code order_by=-id}), not paginated further. If the tagged run has been
+     * pushed past that window by that many newer runs of the same job (e.g. after a long worker
+     * downtime on a very actively scheduled job), it will not be found and a fresh run is triggered
+     * instead, which can result in a duplicate in that rare case.
      */
-    private Run findInFlightRun(RunContext runContext) throws Exception {
+    private Run findRunForThisTaskRun(RunContext runContext) throws Exception {
         HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
             .uri(
                 URI.create(
                     runContext.render(this.baseUrl).as(String.class).orElseThrow() + "/api/v2/accounts/" + runContext.render(this.accountId).as(String.class).orElseThrow() +
                         "/runs/?job_definition_id=" + runContext.render(this.jobId).as(String.class).orElseThrow() +
-                        "&status__in=" + URLEncoder.encode("[1,2,3]", StandardCharsets.UTF_8) +
                         "&order_by=-id" +
+                        "&limit=" + FIND_RUN_LOOKUP_LIMIT +
                         "&include_related=" + URLEncoder.encode("[\"trigger\"]", StandardCharsets.UTF_8)
                 )
             )
@@ -269,6 +316,32 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
             )
             .findFirst()
             .orElse(null);
+    }
+
+    /**
+     * After a trigger call fails ambiguously (the request may already have reached dbt Cloud), check
+     * whether it actually created a run before giving up. A run that was just created can take a
+     * moment to appear in the run list, so this retries a few times with a short pause rather than
+     * concluding "no run" on the first empty result.
+     */
+    private Run confirmRunAfterAmbiguousFailure(RunContext runContext) throws Exception {
+        for (int attempt = 1; attempt <= CONFIRM_LOOKUP_MAX_ATTEMPTS; attempt++) {
+            Run found = this.findRunForThisTaskRun(runContext);
+            if (found != null) {
+                return found;
+            }
+            if (attempt < CONFIRM_LOOKUP_MAX_ATTEMPTS) {
+                try {
+                    Thread.sleep(CONFIRM_LOOKUP_BACKOFF.toMillis());
+                } catch (InterruptedException ie) {
+                    // Stop looking rather than propagate: the caller must fall through to rethrow the
+                    // original trigger failure, not fail on an interrupted backoff.
+                    Thread.currentThread().interrupt();
+                    return null;
+                }
+            }
+        }
+        return null;
     }
 
     /** The marker embedded in a run's cause so a reattach can identify the run this taskrun started. */

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -7,6 +7,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiPredicate;
 
 import org.slf4j.Logger;
 
@@ -150,11 +151,12 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
             cause) instead of triggering a duplicate. On a worker restart or retry it adopts an in-flight or \
             already-succeeded run, so a delayed retry after a lost response does not duplicate, but lets a \
             failed or cancelled run re-trigger. If the trigger call itself fails with an ambiguous error \
-            (e.g. a timeout) that may mean dbt Cloud already received it, it confirms and adopts the run \
-            this attempt created (never a stale run left over from a prior attempt) and reports its real \
-            outcome. A residual gap remains: a transparent internal retry of the trigger POST itself on a \
-            502/503/504 can still double-trigger; this is not solved by reattach. Default false, which \
-            always triggers a new run."""
+            (a read timeout, a mid-flight drop, or a 502/504 gateway error) that may mean dbt Cloud already \
+            received it, it confirms and adopts the run this attempt created (never a stale run left over \
+            from a prior attempt) and reports its real outcome. A small residual gap remains: a 503 on the \
+            trigger POST is still retried internally, since a 503 almost always means the request never \
+            reached dbt Cloud, so in a rare case it could double-trigger. Default false, which always \
+            triggers a new run."""
     )
     @Builder.Default
     @PluginProperty(group = "reliability")
@@ -240,11 +242,22 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
                     .build()
             );
 
+        // The trigger POST is not idempotent, so when reattach is on it must not be blindly retried by the
+        // generic HTTP layer on an ambiguous failure, since a retry could start the job twice. Keep the safe
+        // transient retries (503, TLS handshake, refused connection) but let an ambiguous failure (read
+        // timeout, mid-flight drop, or a 502/504 gateway error) surface here, where we can confirm and adopt
+        // the run it may already have created. When reattach is off, behave exactly as before.
+        BiPredicate<Throwable, String> triggerRetry = reattachEnabled
+            ? (throwable, method) -> isRetriableTransientError(throwable, method) && !isAmbiguousFailure(throwable)
+            : AbstractDbtCloud::isRetriableTransientError;
+
         HttpResponse<RunResponse> triggerResponse;
         try {
-            triggerResponse = this.request(runContext, requestBuilder, RunResponse.class);
+            triggerResponse = this.request(runContext, requestBuilder, RunResponse.class, triggerRetry);
         } catch (Exception e) {
-            // An ambiguous failure may mean dbt already created the run, so confirm before failing.
+            // An ambiguous failure may mean dbt already created the run, so confirm and adopt it before failing.
+            // If no run was created the original failure is rethrown; a task-level retry then triggers a fresh
+            // run and the start-of-run reattach above adopts it, so there is no in-task re-POST to duplicate.
             if (reattachEnabled && isAmbiguousFailure(e)) {
                 Run adoptedRun = null;
                 try {

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -302,7 +302,7 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
      * run's id (0 if none), so a later confirm never mistakes it for a run created by this attempt.
      */
     private StartLookup findStartOfRunLookup(RunContext runContext) throws Exception {
-        List<Run> firstPage = this.fetchRunsPage(runContext, 0);
+        List<Run> firstPage = this.fetchRunsPage(runContext, 0, 0L);
 
         // Baseline is the newest run id of the job (any status) seen before the POST, so a later confirm
         // only adopts a run created after it and never a stale run from a prior attempt. Using the newest
@@ -339,7 +339,7 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     private Run findRunCreatedByThisTaskRun(RunContext runContext, long baseline) throws Exception {
         String tag = taskrunTag(runContext);
         for (int page = 0; page < FIND_RUN_CONFIRM_MAX_PAGES; page++) {
-            List<Run> runs = this.fetchRunsPage(runContext, page * FIND_RUN_LOOKUP_LIMIT);
+            List<Run> runs = this.fetchRunsPage(runContext, page * FIND_RUN_LOOKUP_LIMIT, baseline);
             if (runs.isEmpty()) {
                 return null;
             }
@@ -365,8 +365,10 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
         return null;
     }
 
-    // One page of the job's runs, newest first (order_by=-id), from the given offset.
-    private List<Run> fetchRunsPage(RunContext runContext, int offset) throws Exception {
+    // One page of the job's runs, newest first (order_by=-id), from the given offset. When idGt > 0 the
+    // dbt Cloud `id__gt` filter returns only runs newer than it, so the confirm lookup scans just the
+    // runs created after its baseline instead of the whole newest-100, which is usually a single page.
+    private List<Run> fetchRunsPage(RunContext runContext, int offset, long idGt) throws Exception {
         HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
             .uri(
                 URI.create(
@@ -375,6 +377,7 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
                         "&order_by=-id" +
                         "&limit=" + FIND_RUN_LOOKUP_LIMIT +
                         "&offset=" + offset +
+                        (idGt > 0 ? "&id__gt=" + idGt : "") +
                         "&include_related=" + URLEncoder.encode("[\"trigger\"]", StandardCharsets.UTF_8)
                 )
             )

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -153,10 +153,12 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
             failed or cancelled run re-trigger. If the trigger call itself fails with an ambiguous error \
             (a read timeout, a mid-flight drop, or a 502/504 gateway error) that may mean dbt Cloud already \
             received it, it confirms and adopts the run this attempt created (never a stale run left over \
-            from a prior attempt) and reports its real outcome. A small residual gap remains: a 503 on the \
+            from a prior attempt) and reports its real outcome. Two small residual gaps remain. A 503 on the \
             trigger POST is still retried internally, since a 503 almost always means the request never \
-            reached dbt Cloud, so in a rare case it could double-trigger. Default false, which always \
-            triggers a new run."""
+            reached dbt Cloud, so in a rare case it could double-trigger. And the restart or retry check \
+            scans only the most recent runs of the job, so on a very busy or heavily shared job that has \
+            accumulated a large backlog of runs since this one started, it may not find the earlier run and \
+            could trigger a duplicate. Default false, which always triggers a new run."""
     )
     @Builder.Default
     @PluginProperty(group = "reliability")
@@ -294,6 +296,11 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     // flood of runs cannot loop unbounded. FIND_RUN_LOOKUP_LIMIT times this is the deepest it looks.
     private static final int FIND_RUN_CONFIRM_MAX_PAGES = 10;
 
+    // Pages the start-of-run reattach walks looking for an earlier run of this taskrun. Unlike the confirm
+    // path it has no baseline to stop at, so on a first attempt (no earlier run) it walks up to this many
+    // pages before giving up. Kept small so the cost on the common first-attempt path stays bounded.
+    private static final int FIND_RUN_START_MAX_PAGES = 5;
+
     /**
      * Single start-of-run lookup, yielding both the adopt decision and the baseline for the later
      * ambiguous-failure confirm path. Adopts an in-flight or succeeded run (so a delayed retry after a
@@ -302,23 +309,28 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
      * run's id (0 if none), so a later confirm never mistakes it for a run created by this attempt.
      */
     private StartLookup findStartOfRunLookup(RunContext runContext) throws Exception {
-        List<Run> firstPage = this.fetchRunsPage(runContext, 0, 0L);
-
-        // Baseline is the newest run id of the job (any status) seen before the POST, so a later confirm
-        // only adopts a run created after it and never a stale run from a prior attempt. Using the newest
-        // run overall, not just a tagged one, keeps it a tight, always-available floor for the confirm
-        // pagination even when this taskrun has no earlier run.
-        long baseline = firstPage.stream()
-            .map(Run::getId)
-            .filter(id -> id != null)
-            .findFirst()
-            .orElse(0L);
-
         String tag = taskrunTag(runContext);
-        Run tagged = firstPage.stream()
-            .filter(run -> matchesTaskrunTag(run, tag))
-            .findFirst()
-            .orElse(null);
+        long baseline = 0L;
+        Run tagged = null;
+
+        // Walk newest-first for an earlier run of this taskrun. Paginate so a busy job that has pushed the
+        // earlier run past the first page does not silently miss it and trigger a duplicate. Bounded by
+        // FIND_RUN_START_MAX_PAGES since, with no earlier run to find, there is no baseline to stop at.
+        for (int page = 0; page < FIND_RUN_START_MAX_PAGES; page++) {
+            List<Run> runs = this.fetchRunsPage(runContext, page * FIND_RUN_LOOKUP_LIMIT, 0L);
+            if (runs.isEmpty()) {
+                break;
+            }
+            if (page == 0) {
+                // Baseline is the newest run id of the job (any status) seen before the POST, so a later
+                // confirm only adopts a run created after it and never a stale run from a prior attempt.
+                baseline = runs.stream().map(Run::getId).filter(id -> id != null).findFirst().orElse(0L);
+            }
+            tagged = runs.stream().filter(run -> matchesTaskrunTag(run, tag)).findFirst().orElse(null);
+            if (tagged != null || runs.size() < FIND_RUN_LOOKUP_LIMIT) {
+                break;
+            }
+        }
 
         // Adopt an in-flight or succeeded run, but never an Error or Cancelled one, so a genuine failure
         // lets the retry or restart re-trigger instead of re-reporting the old failure.

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -18,6 +18,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.dbt.cloud.models.JobStatus;
 import io.kestra.plugin.dbt.cloud.models.Run;
 import io.kestra.plugin.dbt.cloud.models.RunListResponse;
 import io.kestra.plugin.dbt.cloud.models.RunResponse;
@@ -144,10 +145,16 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     @Schema(
         title = "Reattach to an in-flight run",
         description = """
-            If true, the task reattaches to a run it already started instead of triggering a duplicate: at the \
-            start of a worker restart or retry, and when the trigger call itself fails with an ambiguous error \
-            (e.g. a timeout) that may mean dbt Cloud already received it. It only reattaches to a run this \
-            execution started (matched by the taskrun id in the run cause), never one triggered elsewhere. \
+            If true, the task reattaches to a run it already started instead of triggering a duplicate. This is \
+            checked at the start of a worker restart or retry: a run this taskrun started that is still queued, \
+            starting, running, or already succeeded is adopted, so a delayed retry after a lost response does not \
+            trigger a duplicate. A run that genuinely failed or was cancelled is NOT adopted at this point, so a \
+            task-level `retry` or a manual "Restart from failed task" still triggers a fresh run instead of \
+            silently re-reporting the old failure. It is also checked when the trigger call itself fails with an \
+            ambiguous error (e.g. a timeout) that may mean dbt Cloud already received it: in that case any \
+            matching run is adopted regardless of status, since it was just created by the call that timed out and \
+            its real outcome (success or failure) must be reported for this attempt. It only reattaches to a run \
+            this execution started (matched by the taskrun id in the run cause), never one triggered elsewhere. \
             Default false, which always triggers a new run."""
     )
     @Builder.Default
@@ -183,7 +190,7 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
         boolean reattachEnabled = Boolean.TRUE.equals(runContext.render(this.reattach).as(Boolean.class).orElse(Boolean.FALSE));
 
         if (reattachEnabled) {
-            Run existingRun = this.findRunForThisTaskRun(runContext);
+            var existingRun = this.findReattachableRunForThisTaskRun(runContext);
             if (existingRun != null) {
                 logger.info(
                     "Reattached to run {} (status {}) already started by this taskrun instead of triggering a new one",
@@ -274,10 +281,27 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     private static final int FIND_RUN_LOOKUP_LIMIT = 100;
 
     /**
+     * Start-of-run reattach check (worker restart, task-level {@code retry}, manual restart from a
+     * failed task). Adopts a run this taskrun already started only if it is still in flight (queued,
+     * starting, running) or already succeeded, never one that ended in Error or Cancelled: a genuinely
+     * failed dbt run must let the retry / restart re-trigger a fresh attempt instead of silently
+     * re-adopting and re-reporting the same historical failure. A succeeded run is still adopted so a
+     * delayed retry after a lost response does not create a duplicate.
+     */
+    private Run findReattachableRunForThisTaskRun(RunContext runContext) throws Exception {
+        var run = this.findRunForThisTaskRun(runContext);
+        if (run == null || run.getStatus() == JobStatus.NUMBER_20 || run.getStatus() == JobStatus.NUMBER_30) {
+            return null;
+        }
+        return run;
+    }
+
+    /**
      * Look for a run of the job that this taskrun already started, matched strictly by the taskrun
      * tag in the run cause: that tag is the unique key, so any status (queued, running, or already
-     * finished) qualifies. A finished run must be adopted and its real outcome reported by
-     * {@link #waitOrReturn}, never re-triggered. Returns null when there is none, in which case a
+     * finished, whether success or failure) qualifies. Callers that need to only adopt an in-flight or
+     * successful run (and let a genuine failure re-trigger) must filter the result themselves, e.g. via
+     * {@link #findReattachableRunForThisTaskRun}. Returns null when there is none, in which case a
      * fresh run is triggered rather than attaching to a run this execution did not start.
      *
      * <p>
@@ -326,7 +350,7 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
      */
     private Run confirmRunAfterAmbiguousFailure(RunContext runContext) throws Exception {
         for (int attempt = 1; attempt <= CONFIRM_LOOKUP_MAX_ATTEMPTS; attempt++) {
-            Run found = this.findRunForThisTaskRun(runContext);
+            var found = this.findRunForThisTaskRun(runContext);
             if (found != null) {
                 return found;
             }

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -148,8 +148,11 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
             cause) instead of triggering a duplicate. On a worker restart or retry it adopts an in-flight or \
             already-succeeded run, so a delayed retry after a lost response does not duplicate, but lets a \
             failed or cancelled run re-trigger. If the trigger call itself fails with an ambiguous error \
-            (e.g. a timeout) that may mean dbt Cloud already received it, it adopts any matching run and \
-            reports its real outcome. Default false, which always triggers a new run."""
+            (e.g. a timeout) that may mean dbt Cloud already received it, it confirms and adopts the run \
+            this attempt created (never a stale run left over from a prior attempt) and reports its real \
+            outcome. A residual gap remains: a transparent internal retry of the trigger POST itself on a \
+            502/503/504 can still double-trigger; this is not solved by reattach. Default false, which \
+            always triggers a new run."""
     )
     @Builder.Default
     @PluginProperty(group = "reliability")
@@ -183,15 +186,19 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
 
         boolean reattachEnabled = Boolean.TRUE.equals(runContext.render(this.reattach).as(Boolean.class).orElse(Boolean.FALSE));
 
+        // Baseline id of the newest tagged run seen before the POST below, used by the ambiguous-failure
+        // confirm path to reject a stale run left over from a prior attempt (same taskrun id, reused tag).
+        long baseline = 0L;
         if (reattachEnabled) {
-            var existingRun = this.findReattachableRunForThisTaskRun(runContext);
-            if (existingRun != null) {
+            StartLookup lookup = this.findStartOfRunLookup(runContext);
+            if (lookup.adoptableRun() != null) {
                 logger.info(
                     "Reattached to run {} (status {}) already started by this taskrun instead of triggering a new one",
-                    existingRun.getId(), existingRun.getStatus()
+                    lookup.adoptableRun().getId(), lookup.adoptableRun().getStatus()
                 );
-                return this.waitOrReturn(runContext, existingRun.getId());
+                return this.waitOrReturn(runContext, lookup.adoptableRun().getId());
             }
+            baseline = lookup.baseline();
         }
 
         // trigger
@@ -239,7 +246,7 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
             if (reattachEnabled && wasPossiblySent(e)) {
                 Run adoptedRun = null;
                 try {
-                    adoptedRun = this.confirmRunAfterAmbiguousFailure(runContext);
+                    adoptedRun = this.confirmRunAfterAmbiguousFailure(runContext, baseline);
                 } catch (Exception confirmEx) {
                     // A failed confirm must not mask the original trigger failure.
                     logger.warn("Could not confirm whether the ambiguous trigger call created a run: {}", confirmEx.getMessage());
@@ -269,21 +276,25 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     private static final int FIND_RUN_LOOKUP_LIMIT = 100;
 
     /**
-     * Start-of-run reattach check. Adopts an in-flight or succeeded run (so a delayed retry after a lost
-     * response does not duplicate), but never an Error or Cancelled one, so a genuine failure lets the
-     * retry or restart re-trigger instead of re-reporting the old failure.
+     * Single start-of-run lookup, yielding both the adopt decision and the baseline for the later
+     * ambiguous-failure confirm path. Adopts an in-flight or succeeded run (so a delayed retry after a
+     * lost response does not duplicate), but never an Error or Cancelled one, so a genuine failure lets
+     * the retry or restart re-trigger instead of re-reporting the old failure. The baseline is that same
+     * run's id (0 if none), so a later confirm never mistakes it for a run created by this attempt.
      */
-    private Run findReattachableRunForThisTaskRun(RunContext runContext) throws Exception {
+    private StartLookup findStartOfRunLookup(RunContext runContext) throws Exception {
         var run = this.findRunForThisTaskRun(runContext);
-        if (run == null || run.getStatus() == JobStatus.NUMBER_20 || run.getStatus() == JobStatus.NUMBER_30) {
-            return null;
-        }
-        return run;
+        long baseline = (run != null && run.getId() != null) ? run.getId() : 0L;
+        boolean adoptable = run != null && run.getStatus() != JobStatus.NUMBER_20 && run.getStatus() != JobStatus.NUMBER_30;
+        return new StartLookup(adoptable ? run : null, baseline);
+    }
+
+    private record StartLookup(Run adoptableRun, long baseline) {
     }
 
     /**
      * Find a run this taskrun started, matched by its tag in the run cause, in any status. Callers that
-     * must not adopt a failed run filter via {@link #findReattachableRunForThisTaskRun}. Bounded to the
+     * must not adopt a failed run filter via {@link #findStartOfRunLookup}. Bounded to the
      * {@value #FIND_RUN_LOOKUP_LIMIT} newest runs of the job, not paginated further.
      */
     private Run findRunForThisTaskRun(RunContext runContext) throws Exception {
@@ -319,12 +330,15 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
 
     /**
      * After an ambiguous trigger failure, check whether the run was created, retrying a few times since
-     * a just-created run can take a moment to appear in the run list.
+     * a just-created run can take a moment to appear in the run list. Only a run whose id is strictly
+     * greater than {@code baseline} is accepted: the tag in the run cause is reused across retries of the
+     * same taskrun, so the newest tagged run at this point could still be a stale run from a prior
+     * attempt (id == baseline) rather than the one this attempt's POST just created.
      */
-    private Run confirmRunAfterAmbiguousFailure(RunContext runContext) throws Exception {
+    private Run confirmRunAfterAmbiguousFailure(RunContext runContext, long baseline) throws Exception {
         for (int attempt = 1; attempt <= CONFIRM_LOOKUP_MAX_ATTEMPTS; attempt++) {
             var found = this.findRunForThisTaskRun(runContext);
-            if (found != null) {
+            if (found != null && found.getId() != null && found.getId() > baseline) {
                 return found;
             }
             if (attempt < CONFIRM_LOOKUP_MAX_ATTEMPTS) {

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -61,8 +61,7 @@ import lombok.experimental.SuperBuilder;
 )
 public class TriggerRun extends AbstractDbtCloud implements RunnableTask<TriggerRun.Output> {
 
-    // Bounded retry for the post-failure confirm-and-adopt lookup: a run that was just created by an
-    // ambiguous (possibly-sent) trigger call can take a moment to show up in the run list.
+    // A just-created run can take a moment to show up in the run list.
     private static final int CONFIRM_LOOKUP_MAX_ATTEMPTS = 3;
     private static final Duration CONFIRM_LOOKUP_BACKOFF = Duration.ofSeconds(1);
 
@@ -145,17 +144,12 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     @Schema(
         title = "Reattach to an in-flight run",
         description = """
-            If true, the task reattaches to a run it already started instead of triggering a duplicate. This is \
-            checked at the start of a worker restart or retry: a run this taskrun started that is still queued, \
-            starting, running, or already succeeded is adopted, so a delayed retry after a lost response does not \
-            trigger a duplicate. A run that genuinely failed or was cancelled is NOT adopted at this point, so a \
-            task-level `retry` or a manual "Restart from failed task" still triggers a fresh run instead of \
-            silently re-reporting the old failure. It is also checked when the trigger call itself fails with an \
-            ambiguous error (e.g. a timeout) that may mean dbt Cloud already received it: in that case any \
-            matching run is adopted regardless of status, since it was just created by the call that timed out and \
-            its real outcome (success or failure) must be reported for this attempt. It only reattaches to a run \
-            this execution started (matched by the taskrun id in the run cause), never one triggered elsewhere. \
-            Default false, which always triggers a new run."""
+            If true, the task reattaches to a run it already started (matched by the taskrun id in the run \
+            cause) instead of triggering a duplicate. On a worker restart or retry it adopts an in-flight or \
+            already-succeeded run, so a delayed retry after a lost response does not duplicate, but lets a \
+            failed or cancelled run re-trigger. If the trigger call itself fails with an ambiguous error \
+            (e.g. a timeout) that may mean dbt Cloud already received it, it adopts any matching run and \
+            reports its real outcome. Default false, which always triggers a new run."""
     )
     @Builder.Default
     @PluginProperty(group = "reliability")
@@ -241,17 +235,13 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
         try {
             triggerResponse = this.request(runContext, requestBuilder, RunResponse.class);
         } catch (Exception e) {
-            // Only when reattach is on (a marker was written above) is a lookup reliable: an ambiguous
-            // failure (read timeout, mid-flight drop) may mean dbt Cloud already created the run, so
-            // confirm before failing loud and creating a duplicate on the next retry.
+            // An ambiguous failure may mean dbt already created the run, so confirm before failing.
             if (reattachEnabled && wasPossiblySent(e)) {
                 Run adoptedRun = null;
                 try {
                     adoptedRun = this.confirmRunAfterAmbiguousFailure(runContext);
                 } catch (Exception confirmEx) {
-                    // The confirm-lookup itself failing (the GET exhausting retries, an interrupted
-                    // backoff) must never mask the original trigger failure below: log and fall
-                    // through so `e` is the one rethrown.
+                    // A failed confirm must not mask the original trigger failure.
                     logger.warn("Could not confirm whether the ambiguous trigger call created a run: {}", confirmEx.getMessage());
                 }
                 if (adoptedRun != null) {
@@ -275,18 +265,13 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
         return this.waitOrReturn(runContext, triggerRunResponse.getData().getId());
     }
 
-    // Bounds the run-list lookup below to the most recent runs of the job. `order_by=-id` puts the
-    // newest run first, so the tagged run is only missed if more than this many newer runs of the
-    // same job were created since it started: a residual limitation, documented on the method itself.
+    // Newest first, so the tagged run is only missed if this many newer runs of the job appeared since.
     private static final int FIND_RUN_LOOKUP_LIMIT = 100;
 
     /**
-     * Start-of-run reattach check (worker restart, task-level {@code retry}, manual restart from a
-     * failed task). Adopts a run this taskrun already started only if it is still in flight (queued,
-     * starting, running) or already succeeded, never one that ended in Error or Cancelled: a genuinely
-     * failed dbt run must let the retry / restart re-trigger a fresh attempt instead of silently
-     * re-adopting and re-reporting the same historical failure. A succeeded run is still adopted so a
-     * delayed retry after a lost response does not create a duplicate.
+     * Start-of-run reattach check. Adopts an in-flight or succeeded run (so a delayed retry after a lost
+     * response does not duplicate), but never an Error or Cancelled one, so a genuine failure lets the
+     * retry or restart re-trigger instead of re-reporting the old failure.
      */
     private Run findReattachableRunForThisTaskRun(RunContext runContext) throws Exception {
         var run = this.findRunForThisTaskRun(runContext);
@@ -297,19 +282,9 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     }
 
     /**
-     * Look for a run of the job that this taskrun already started, matched strictly by the taskrun
-     * tag in the run cause: that tag is the unique key, so any status (queued, running, or already
-     * finished, whether success or failure) qualifies. Callers that need to only adopt an in-flight or
-     * successful run (and let a genuine failure re-trigger) must filter the result themselves, e.g. via
-     * {@link #findReattachableRunForThisTaskRun}. Returns null when there is none, in which case a
-     * fresh run is triggered rather than attaching to a run this execution did not start.
-     *
-     * <p>
-     * The lookup is bounded to the {@value #FIND_RUN_LOOKUP_LIMIT} most recent runs of the job
-     * (newest first via {@code order_by=-id}), not paginated further. If the tagged run has been
-     * pushed past that window by that many newer runs of the same job (e.g. after a long worker
-     * downtime on a very actively scheduled job), it will not be found and a fresh run is triggered
-     * instead, which can result in a duplicate in that rare case.
+     * Find a run this taskrun started, matched by its tag in the run cause, in any status. Callers that
+     * must not adopt a failed run filter via {@link #findReattachableRunForThisTaskRun}. Bounded to the
+     * {@value #FIND_RUN_LOOKUP_LIMIT} newest runs of the job, not paginated further.
      */
     private Run findRunForThisTaskRun(RunContext runContext) throws Exception {
         HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
@@ -343,10 +318,8 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
     }
 
     /**
-     * After a trigger call fails ambiguously (the request may already have reached dbt Cloud), check
-     * whether it actually created a run before giving up. A run that was just created can take a
-     * moment to appear in the run list, so this retries a few times with a short pause rather than
-     * concluding "no run" on the first empty result.
+     * After an ambiguous trigger failure, check whether the run was created, retrying a few times since
+     * a just-created run can take a moment to appear in the run list.
      */
     private Run confirmRunAfterAmbiguousFailure(RunContext runContext) throws Exception {
         for (int attempt = 1; attempt <= CONFIRM_LOOKUP_MAX_ATTEMPTS; attempt++) {
@@ -358,8 +331,7 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
                 try {
                     Thread.sleep(CONFIRM_LOOKUP_BACKOFF.toMillis());
                 } catch (InterruptedException ie) {
-                    // Stop looking rather than propagate: the caller must fall through to rethrow the
-                    // original trigger failure, not fail on an interrupted backoff.
+                    // Stop looking; let the caller rethrow the original trigger failure.
                     Thread.currentThread().interrupt();
                     return null;
                 }

--- a/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/TriggerRun.java
@@ -287,8 +287,12 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
         return this.waitOrReturn(runContext, triggerRunResponse.getData().getId());
     }
 
-    // Newest first, so the tagged run is only missed if this many newer runs of the job appeared since.
+    // Page size for the run-list lookup, newest first (order_by=-id).
     private static final int FIND_RUN_LOOKUP_LIMIT = 100;
+
+    // Safety cap on how many pages the confirm lookup walks back before giving up, so a pathological
+    // flood of runs cannot loop unbounded. FIND_RUN_LOOKUP_LIMIT times this is the deepest it looks.
+    private static final int FIND_RUN_CONFIRM_MAX_PAGES = 10;
 
     /**
      * Single start-of-run lookup, yielding both the adopt decision and the baseline for the later
@@ -298,21 +302,71 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
      * run's id (0 if none), so a later confirm never mistakes it for a run created by this attempt.
      */
     private StartLookup findStartOfRunLookup(RunContext runContext) throws Exception {
-        var run = this.findRunForThisTaskRun(runContext);
-        long baseline = (run != null && run.getId() != null) ? run.getId() : 0L;
-        boolean adoptable = run != null && run.getStatus() != JobStatus.NUMBER_20 && run.getStatus() != JobStatus.NUMBER_30;
-        return new StartLookup(adoptable ? run : null, baseline);
+        List<Run> firstPage = this.fetchRunsPage(runContext, 0);
+
+        // Baseline is the newest run id of the job (any status) seen before the POST, so a later confirm
+        // only adopts a run created after it and never a stale run from a prior attempt. Using the newest
+        // run overall, not just a tagged one, keeps it a tight, always-available floor for the confirm
+        // pagination even when this taskrun has no earlier run.
+        long baseline = firstPage.stream()
+            .map(Run::getId)
+            .filter(id -> id != null)
+            .findFirst()
+            .orElse(0L);
+
+        String tag = taskrunTag(runContext);
+        Run tagged = firstPage.stream()
+            .filter(run -> matchesTaskrunTag(run, tag))
+            .findFirst()
+            .orElse(null);
+
+        // Adopt an in-flight or succeeded run, but never an Error or Cancelled one, so a genuine failure
+        // lets the retry or restart re-trigger instead of re-reporting the old failure.
+        boolean adoptable = tagged != null && tagged.getStatus() != JobStatus.NUMBER_20 && tagged.getStatus() != JobStatus.NUMBER_30;
+        return new StartLookup(adoptable ? tagged : null, baseline);
     }
 
     private record StartLookup(Run adoptableRun, long baseline) {
     }
 
     /**
-     * Find a run this taskrun started, matched by its tag in the run cause, in any status. Callers that
-     * must not adopt a failed run filter via {@link #findStartOfRunLookup}. Bounded to the
-     * {@value #FIND_RUN_LOOKUP_LIMIT} newest runs of the job, not paginated further.
+     * Find the run this attempt's POST created after an ambiguous failure. Matched by the taskrun tag and
+     * required to be newer than {@code baseline} (the newest run seen before the POST), so a stale run
+     * from a prior attempt is never mistaken for it. Pages newest-first until the run is found, or a page
+     * crosses the baseline (every run newer than it has been seen, so none was created), or the page cap
+     * is hit. Returns null in the not-found cases, and the caller then rethrows the original failure.
      */
-    private Run findRunForThisTaskRun(RunContext runContext) throws Exception {
+    private Run findRunCreatedByThisTaskRun(RunContext runContext, long baseline) throws Exception {
+        String tag = taskrunTag(runContext);
+        for (int page = 0; page < FIND_RUN_CONFIRM_MAX_PAGES; page++) {
+            List<Run> runs = this.fetchRunsPage(runContext, page * FIND_RUN_LOOKUP_LIMIT);
+            if (runs.isEmpty()) {
+                return null;
+            }
+            for (Run run : runs) {
+                if (run.getId() != null && run.getId() <= baseline) {
+                    // Reached the pre-POST baseline: a run this attempt created (id > baseline) would
+                    // already have been seen, so there is none.
+                    return null;
+                }
+                if (matchesTaskrunTag(run, tag)) {
+                    return run;
+                }
+            }
+            if (runs.size() < FIND_RUN_LOOKUP_LIMIT) {
+                // Short page: the list is exhausted with no matching run.
+                return null;
+            }
+        }
+        runContext.logger().warn(
+            "Confirm lookup walked {} pages without reaching baseline run id {}; a created run may have been missed",
+            FIND_RUN_CONFIRM_MAX_PAGES, baseline
+        );
+        return null;
+    }
+
+    // One page of the job's runs, newest first (order_by=-id), from the given offset.
+    private List<Run> fetchRunsPage(RunContext runContext, int offset) throws Exception {
         HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
             .uri(
                 URI.create(
@@ -320,6 +374,7 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
                         "/runs/?job_definition_id=" + runContext.render(this.jobId).as(String.class).orElseThrow() +
                         "&order_by=-id" +
                         "&limit=" + FIND_RUN_LOOKUP_LIMIT +
+                        "&offset=" + offset +
                         "&include_related=" + URLEncoder.encode("[\"trigger\"]", StandardCharsets.UTF_8)
                 )
             )
@@ -328,28 +383,23 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
         HttpResponse<RunListResponse> response = this.request(runContext, requestBuilder, RunListResponse.class);
 
         RunListResponse listResponse = response.getBody();
-        if (listResponse == null || listResponse.getData() == null || listResponse.getData().isEmpty()) {
-            return null;
+        if (listResponse == null || listResponse.getData() == null) {
+            return List.of();
         }
+        return listResponse.getData();
+    }
 
-        String tag = taskrunTag(runContext);
-        return listResponse.getData().stream()
-            .filter(
-                run -> run.getTrigger() != null
-                    && run.getTrigger().getCause() != null
-                    && run.getTrigger().getCause().contains(tag)
-            )
-            .findFirst()
-            .orElse(null);
+    private static boolean matchesTaskrunTag(Run run, String tag) {
+        return run.getTrigger() != null
+            && run.getTrigger().getCause() != null
+            && run.getTrigger().getCause().contains(tag);
     }
 
     /**
-     * After an ambiguous trigger failure, check whether the run was created, retrying the lookup a few
-     * times since a just-created run can take a moment to appear in the run list. Only a run whose id is
-     * strictly greater than {@code baseline} is accepted: the tag in the run cause is reused across
-     * retries of the same taskrun, so the newest tagged run could still be a stale run from a prior
-     * attempt (id == baseline) rather than the one this attempt's POST just created. Throws once the
-     * attempts are exhausted without such a run, which the caller treats as "not created".
+     * After an ambiguous trigger failure, check whether the run was created, retrying the paginated lookup
+     * a few times since a just-created run can take a moment to appear in the run list. The baseline and
+     * tag matching are handled by {@link #findRunCreatedByThisTaskRun}. Throws once the attempts are
+     * exhausted without a match, which the caller treats as "not created".
      */
     private Run confirmRunAfterAmbiguousFailure(RunContext runContext, long baseline) throws Exception {
         return RetryUtils.<Run, Exception> of(
@@ -359,8 +409,10 @@ public class TriggerRun extends AbstractDbtCloud implements RunnableTask<Trigger
                 .build()
         )
             .run(
-                (run, throwable) -> throwable == null && (run == null || run.getId() == null || run.getId() <= baseline),
-                () -> this.findRunForThisTaskRun(runContext)
+                // findRunCreatedByThisTaskRun already applies the baseline, so retry only while it has not
+                // yet surfaced (a just-created run can lag in the run list for a moment).
+                (run, throwable) -> throwable == null && run == null,
+                () -> this.findRunCreatedByThisTaskRun(runContext, baseline)
             );
     }
 

--- a/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
@@ -655,4 +655,125 @@ class MockTriggerRunTest {
         verify(0, getRequestedFor(urlPathEqualTo("/api/v2/accounts/123/runs/")));
         verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
     }
+
+    @Test
+    void testDoesNotAdoptStaleRunFromPriorAttempt() throws Exception {
+        // Regression: a prior attempt's run (same taskrun id, tag reused) failed with status 20 (Error).
+        // This attempt's own POST times out, and every confirm lookup afterward still only turns up that
+        // same stale run, never a newer id. The original timeout must surface, never the stale run's
+        // Error outcome, and its id must be rejected as the baseline throughout the confirm loop.
+        HttpConfiguration shortTimeout = HttpConfiguration.builder()
+            .timeout(TimeoutConfiguration.builder().readIdleTimeout(Property.ofValue(Duration.ofMillis(300))).build())
+            .build();
+
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .options(shortTimeout)
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        // every lookup (the start-of-run check AND every confirm retry) only ever turns up the stale,
+        // already-failed run left over from a prior attempt
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[{\"id\":501,\"status\":20,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        // this attempt's own POST reaches dbt Cloud (creating run 502) but the response is lost on the wire
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":{\"id\":502}}")
+                        .withFixedDelay(1000)
+                )
+        );
+
+        assertThatThrownBy(() -> task.run(runContext))
+            .hasRootCauseInstanceOf(java.net.SocketTimeoutException.class);
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+    }
+
+    @Test
+    void testAdoptsLaggingNewRunNotStalePriorAttempt() throws Exception {
+        // Prior attempt's run #501 (Error) is the baseline. This attempt's POST times out and creates
+        // run #502, but the confirm lookup lags behind: it first still only shows #501 before #502
+        // appears. Only a run whose id is strictly greater than the baseline may be adopted, so the
+        // stale #501 is rejected even though it matches the same tag, and the loop keeps waiting until
+        // the genuinely new #502 shows up.
+        HttpConfiguration shortTimeout = HttpConfiguration.builder()
+            .timeout(TimeoutConfiguration.builder().readIdleTimeout(Property.ofValue(Duration.ofMillis(300))).build())
+            .build();
+
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .options(shortTimeout)
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        // hit 1 (start-of-run check): only the stale #501 exists yet
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("lagging-new-run")
+                .whenScenarioStateIs(STARTED)
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[{\"id\":501,\"status\":20,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+                .willSetStateTo("confirm attempt 1")
+        );
+        // hit 2 (first confirm retry): still just #501, stale, must be rejected
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("lagging-new-run")
+                .whenScenarioStateIs("confirm attempt 1")
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[{\"id\":501,\"status\":20,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+                .willSetStateTo("new run appeared")
+        );
+        // hit 3 (second confirm retry): the genuinely new, succeeded run #502 has now caught up
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("lagging-new-run")
+                .whenScenarioStateIs("new run appeared")
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[{\"id\":502,\"status\":10,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":{\"id\":502}}")
+                        .withFixedDelay(1000)
+                )
+        );
+
+        TriggerRun.Output output = task.run(runContext);
+
+        // adopted the genuinely new #502, not the stale #501 baseline
+        assertThat(output.getRunId(), is(502L));
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+    }
 }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
@@ -776,4 +776,87 @@ class MockTriggerRunTest {
         assertThat(output.getRunId(), is(502L));
         verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
     }
+
+    @Test
+    void testAdoptsRunAfterGatewayError() throws Exception {
+        // A 504 gateway timeout on the trigger POST is ambiguous: the proxy gave up, but dbt Cloud behind
+        // it may already have received the request and created the run. With reattach on it must NOT be
+        // blindly retried (that would duplicate); it is confirmed and the created run is adopted.
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        // start-of-run lookup finds nothing, then the confirm lookup turns up the run the POST created
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("adopt-on-gateway")
+                .whenScenarioStateIs(STARTED)
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[]}"))
+                .willSetStateTo("run created")
+        );
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("adopt-on-gateway")
+                .whenScenarioStateIs("run created")
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[{\"id\":789,\"status\":10,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        // the trigger POST returns a 504 (the proxy timed out) even though dbt created run 789 behind it
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(aResponse().withStatus(504))
+        );
+
+        TriggerRun.Output output = task.run(runContext);
+
+        assertThat(output.getRunId(), is(789L));
+        // a single POST: the ambiguous 504 was confirmed-and-adopted, never blindly retried into a duplicate
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+    }
+
+    @Test
+    void testGatewayErrorCreatingNoRunIsNotBlindlyRetried() throws Exception {
+        // Same 504, but it created no run. The task must fail with the gateway error and, crucially, must
+        // NOT have re-sent the POST: with reattach on the ambiguous 504 is routed to confirm-and-adopt, not
+        // to the generic HTTP-layer retry that would otherwise re-POST and risk a duplicate.
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+
+        // no run carrying this taskrun's tag ever appears: the 504 genuinely created nothing
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[]}"))
+        );
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(aResponse().withStatus(504))
+        );
+
+        // the original 504 surfaces unmasked (not the confirm lookup's own give-up), and only one POST was sent
+        assertThatThrownBy(() -> task.run(runContext)).isInstanceOf(HttpClientResponseException.class);
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+    }
 }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
@@ -362,6 +362,67 @@ class MockTriggerRunTest {
     }
 
     @Test
+    void testAdoptsRunAfterAmbiguousTriggerTimeoutEvenWhenItFailed() throws Exception {
+        // Same ambiguous-timeout scenario, but the run created by the timed-out POST turns out to have
+        // FAILED (status 20). Unlike the start-of-run check, this inline confirm-and-adopt path must
+        // still adopt it: it was just created by this attempt's own POST, so its real (failed) outcome
+        // has to be reported for this attempt rather than a misleading timeout.
+        HttpConfiguration shortTimeout = HttpConfiguration.builder()
+            .timeout(TimeoutConfiguration.builder().readIdleTimeout(Property.ofValue(Duration.ofMillis(300))).build())
+            .build();
+
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .options(shortTimeout)
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("adopt-on-timeout-failed")
+                .whenScenarioStateIs(STARTED)
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[]}"))
+                .willSetStateTo("run created")
+        );
+
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":{\"id\":789}}")
+                        .withFixedDelay(1000)
+                )
+        );
+
+        // the run this attempt's own POST created genuinely failed
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("adopt-on-timeout-failed")
+                .whenScenarioStateIs("run created")
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[{\"id\":789,\"status\":20,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        TriggerRun.Output output = task.run(runContext);
+
+        // adopted the failed run (wait=false just reports its id; wait=true would surface its failure)
+        assertThat(output.getRunId(), is(789L));
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+    }
+
+    @Test
     void testFailsWhenAmbiguousTimeoutFindsNoMatchingRun() throws Exception {
         HttpConfiguration shortTimeout = HttpConfiguration.builder()
             .timeout(TimeoutConfiguration.builder().readIdleTimeout(Property.ofValue(Duration.ofMillis(300))).build())
@@ -492,5 +553,106 @@ class MockTriggerRunTest {
 
         assertThat(output.getRunId(), is(789L));
         verify(0, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+    }
+
+    @Test
+    void testReattachRetriggersOnGenuinelyFailedRunAtStartOfRun() throws Exception {
+        // Regression test: a run that this taskrun started genuinely FAILED (status 20). A task-level
+        // `retry` (or a manual "Restart from failed task") re-runs this taskrun id, hits the start-of-run
+        // reattach check, and must trigger a fresh run rather than silently re-adopting the same failure.
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(true))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .withQueryParam("include_related", matching(".*trigger.*"))
+                .willReturn(okJson("{\"data\":[{\"id\":789,\"status\":20,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(okJson("{\"data\":{\"id\":790}}"))
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/790/"))
+                .withQueryParam("include_related", matching(".*run_steps.*"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 790,
+                            "status_humanized": "Success",
+                            "duration_humanized": "1m",
+                            "run_steps": []
+                          }
+                        }
+                    """))
+        );
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/790/artifacts/run_results.json"))
+                .willReturn(aResponse().withStatus(404))
+        );
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/790/artifacts/manifest.json"))
+                .willReturn(aResponse().withStatus(404))
+        );
+
+        TriggerRun.Output output = task.run(runContext);
+
+        assertThat(output.getRunId(), is(790L));
+        // did NOT adopt the failed run 789, triggered a fresh one instead
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+    }
+
+    @Test
+    void testReattachOffSkipsLookupAndPropagatesOriginalTimeoutOnPostFailure() throws Exception {
+        // reattach = false: no lookup should ever happen, not at start-of-run and not on an ambiguous
+        // POST failure. The original timeout must propagate untouched and no duplicate POST is sent.
+        HttpConfiguration shortTimeout = HttpConfiguration.builder()
+            .timeout(TimeoutConfiguration.builder().readIdleTimeout(Property.ofValue(Duration.ofMillis(300))).build())
+            .build();
+
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(false))
+            .wait(Property.ofValue(false))
+            .options(shortTimeout)
+            .maxRetries(Property.ofValue(1))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":{\"id\":789}}")
+                        .withFixedDelay(1000)
+                )
+        );
+
+        assertThatThrownBy(() -> task.run(runContext))
+            .hasRootCauseInstanceOf(java.net.SocketTimeoutException.class);
+        verify(0, getRequestedFor(urlPathEqualTo("/api/v2/accounts/123/runs/")));
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
     }
 }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
@@ -978,6 +978,12 @@ class MockTriggerRunTest {
         verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
         // proves it paged past the first 100 rather than giving up on page 1
         verify(getRequestedFor(urlPathEqualTo("/api/v2/accounts/123/runs/")).withQueryParam("offset", equalTo("100")));
+        // and that the confirm lookup scoped server-side to runs created after the baseline (id__gt)
+        verify(
+            getRequestedFor(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .withQueryParam("offset", equalTo("100"))
+                .withQueryParam("id__gt", equalTo("5000"))
+        );
     }
 
     @Test
@@ -1027,5 +1033,53 @@ class MockTriggerRunTest {
         assertThat(output.getRunId(), is(5001L));
         verify(0, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
         verify(getRequestedFor(urlPathEqualTo("/api/v2/accounts/123/runs/")).withQueryParam("offset", equalTo("100")));
+    }
+
+    @Test
+    void testEmptyBodyTriggerResponseConfirmsAndAdopts() throws Exception {
+        // dbt Cloud accepted the trigger (200) and created the run, but the response body was stripped on
+        // the wire. An empty body must be treated as ambiguous and routed to confirm-and-adopt, not fail
+        // raw, so the created run is still adopted rather than duplicated on a retry.
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        // start-of-run lookup finds nothing, then the confirm lookup turns up the run the POST created
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("empty-body")
+                .whenScenarioStateIs(STARTED)
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[]}"))
+                .willSetStateTo("run created")
+        );
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("empty-body")
+                .whenScenarioStateIs("run created")
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[{\"id\":789,\"status\":10,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        // the trigger POST returns 200 with an empty body (created the run, body lost)
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(aResponse().withStatus(200))
+        );
+
+        TriggerRun.Output output = task.run(runContext);
+
+        assertThat(output.getRunId(), is(789L));
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
     }
 }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
@@ -979,4 +979,53 @@ class MockTriggerRunTest {
         // proves it paged past the first 100 rather than giving up on page 1
         verify(getRequestedFor(urlPathEqualTo("/api/v2/accounts/123/runs/")).withQueryParam("offset", equalTo("100")));
     }
+
+    @Test
+    void testStartOfRunReattachPaginatesToFindEarlierRun() throws Exception {
+        // On a restart of a busy job, the run this taskrun started earlier has been pushed off the first
+        // page by 100+ newer runs. The start-of-run reattach check must page past the first 100 to find it
+        // and adopt it, instead of missing it and triggering a duplicate.
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        // page 1 (offset 0): 100 newer, untagged runs, a full page so the lookup must page on
+        StringBuilder floodPage = new StringBuilder("{\"data\":[");
+        for (int i = 0; i < 100; i++) {
+            if (i > 0) {
+                floodPage.append(",");
+            }
+            floodPage.append("{\"id\":").append(5200 - i).append(",\"status\":10,\"trigger\":{\"cause\":\"other\"}}");
+        }
+        floodPage.append("]}");
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .withQueryParam("offset", equalTo("0"))
+                .willReturn(okJson(floodPage.toString()))
+        );
+
+        // page 2 (offset 100): the run this taskrun started earlier, still running, carrying our tag
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .withQueryParam("offset", equalTo("100"))
+                .willReturn(okJson("{\"data\":[{\"id\":5001,\"status\":3,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        TriggerRun.Output output = task.run(runContext);
+
+        // adopted the earlier run found on page 2, and never triggered a new one
+        assertThat(output.getRunId(), is(5001L));
+        verify(0, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+        verify(getRequestedFor(urlPathEqualTo("/api/v2/accounts/123/runs/")).withQueryParam("offset", equalTo("100")));
+    }
 }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
@@ -859,4 +859,124 @@ class MockTriggerRunTest {
         assertThatThrownBy(() -> task.run(runContext)).isInstanceOf(HttpClientResponseException.class);
         verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
     }
+
+    @Test
+    void testRetriedGatewayErrorStillConfirmsAndAdopts() throws Exception {
+        // The POST is retried once on a 503 (safe transient) and then hits an ambiguous 504. The 504 must
+        // still be classified ambiguous, confirmed, and the created run adopted, not misread and hard-failed.
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .initialDelayMs(Property.ofValue(1L))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("gw-retry")
+                .whenScenarioStateIs(STARTED)
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[]}"))
+                .willSetStateTo("gw-created")
+        );
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("gw-retry")
+                .whenScenarioStateIs("gw-created")
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[{\"id\":789,\"status\":10,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .inScenario("gw-retry-post")
+                .whenScenarioStateIs(STARTED)
+                .willReturn(aResponse().withStatus(503))
+                .willSetStateTo("gw-second")
+        );
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .inScenario("gw-retry-post")
+                .whenScenarioStateIs("gw-second")
+                .willReturn(aResponse().withStatus(504))
+        );
+
+        TriggerRun.Output output = task.run(runContext);
+
+        assertThat(output.getRunId(), is(789L));
+    }
+
+    @Test
+    void testConfirmPaginatesToFindRunBeyondFirstPage() throws Exception {
+        // Busy shared job: this attempt's POST creates a run, but a burst of more than 100 newer runs then
+        // pushes it off the first page of the run list. The confirm lookup must page past the first 100 to
+        // find and adopt it, instead of concluding "not created" and letting a retry duplicate the job.
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        // start-of-run: newest run is 5000, untagged -> baseline 5000, nothing to adopt, POST fires
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("flood")
+                .whenScenarioStateIs(STARTED)
+                .withQueryParam("offset", equalTo("0"))
+                .willReturn(okJson("{\"data\":[{\"id\":5000,\"status\":10,\"trigger\":{\"cause\":\"other\"}}]}"))
+                .willSetStateTo("posted")
+        );
+
+        // confirm page 1 (offset 0): 100 newer but untagged runs (5151..5052), a full page, so it must page on
+        StringBuilder floodPage = new StringBuilder("{\"data\":[");
+        for (int i = 0; i < 100; i++) {
+            if (i > 0) {
+                floodPage.append(",");
+            }
+            floodPage.append("{\"id\":").append(5151 - i).append(",\"status\":3,\"trigger\":{\"cause\":\"other\"}}");
+        }
+        floodPage.append("]}");
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("flood")
+                .whenScenarioStateIs("posted")
+                .withQueryParam("offset", equalTo("0"))
+                .willReturn(okJson(floodPage.toString()))
+        );
+
+        // confirm page 2 (offset 100): the run this attempt created, tagged, id 5001 > baseline 5000
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .withQueryParam("offset", equalTo("100"))
+                .willReturn(okJson("{\"data\":[{\"id\":5001,\"status\":10,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(aResponse().withStatus(504))
+        );
+
+        TriggerRun.Output output = task.run(runContext);
+
+        assertThat(output.getRunId(), is(5001L));
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+        // proves it paged past the first 100 rather than giving up on page 1
+        verify(getRequestedFor(urlPathEqualTo("/api/v2/accounts/123/runs/")).withQueryParam("offset", equalTo("100")));
+    }
 }

--- a/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/MockTriggerRunTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.dbt.cloud;
 
+import java.time.Duration;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -7,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 
 import io.kestra.core.http.client.HttpClientResponseException;
+import io.kestra.core.http.client.configurations.HttpConfiguration;
+import io.kestra.core.http.client.configurations.TimeoutConfiguration;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
@@ -18,6 +21,7 @@ import io.kestra.core.utils.TestsUtils;
 import jakarta.inject.Inject;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -62,6 +66,8 @@ class MockTriggerRunTest {
             postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
                 .withRequestBody(matchingJsonPath("$.cause", equalTo("Triggered by Kestra.")))
         );
+        // and no lookup of existing runs is ever made when reattach is off
+        verify(0, getRequestedFor(urlPathEqualTo("/api/v2/accounts/123/runs/")));
     }
 
     @Test
@@ -160,7 +166,6 @@ class MockTriggerRunTest {
         stubFor(
             get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
                 .withQueryParam("job_definition_id", equalTo("456"))
-                .withQueryParam("status__in", equalTo("[1,2,3]"))
                 .withQueryParam("include_related", matching(".*trigger.*"))
                 .willReturn(okJson("{\"data\":[{\"id\":789,\"status\":3,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
         );
@@ -294,5 +299,198 @@ class MockTriggerRunTest {
         assertThatThrownBy(() -> task.run(runContext))
             .isInstanceOf(HttpClientResponseException.class)
             .hasMessageContaining("Failed http request with response code '500'");
+    }
+
+    @Test
+    void testAdoptsRunAfterAmbiguousTriggerTimeout() throws Exception {
+        // A short read timeout lets the delayed trigger response below surface as a SocketTimeoutException,
+        // the same ambiguous failure dbt Cloud produces when the response is lost on the wire mid-flight.
+        HttpConfiguration shortTimeout = HttpConfiguration.builder()
+            .timeout(TimeoutConfiguration.builder().readIdleTimeout(Property.ofValue(Duration.ofMillis(300))).build())
+            .build();
+
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .options(shortTimeout)
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        // no run started by this taskrun yet: the start-of-run reattach lookup finds nothing, so the trigger fires
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("adopt-on-timeout")
+                .whenScenarioStateIs(STARTED)
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[]}"))
+                .willSetStateTo("run created")
+        );
+
+        // the trigger POST reaches dbt Cloud (which creates the run) but its response is lost on the wire
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":{\"id\":789}}")
+                        .withFixedDelay(1000)
+                )
+        );
+
+        // the confirm-and-adopt lookup after the timeout now finds the run this taskrun created
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("adopt-on-timeout")
+                .whenScenarioStateIs("run created")
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[{\"id\":789,\"status\":10,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        TriggerRun.Output output = task.run(runContext);
+
+        assertThat(output.getRunId(), is(789L));
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+    }
+
+    @Test
+    void testFailsWhenAmbiguousTimeoutFindsNoMatchingRun() throws Exception {
+        HttpConfiguration shortTimeout = HttpConfiguration.builder()
+            .timeout(TimeoutConfiguration.builder().readIdleTimeout(Property.ofValue(Duration.ofMillis(300))).build())
+            .build();
+
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .options(shortTimeout)
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+
+        // the lookup never finds a run carrying this taskrun's tag: the POST genuinely never created one
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[]}"))
+        );
+
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":{\"id\":789}}")
+                        .withFixedDelay(1000)
+                )
+        );
+
+        assertThatThrownBy(() -> task.run(runContext))
+            .hasRootCauseInstanceOf(java.net.SocketTimeoutException.class);
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+    }
+
+    @Test
+    void testConfirmLookupFailureDoesNotMaskOriginalFailure() throws Exception {
+        // The trigger POST times out (ambiguous), and the follow-up confirm-and-adopt lookup itself
+        // fails (500). The task must fail loud with the ORIGINAL timeout, never the lookup failure,
+        // and it must not have triggered a duplicate run.
+        HttpConfiguration shortTimeout = HttpConfiguration.builder()
+            .timeout(TimeoutConfiguration.builder().readIdleTimeout(Property.ofValue(Duration.ofMillis(300))).build())
+            .build();
+
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .options(shortTimeout)
+            .maxRetries(Property.ofValue(1))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+
+        // no run started by this taskrun yet: the start-of-run reattach lookup finds nothing, so the trigger fires
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("confirm-lookup-fails")
+                .whenScenarioStateIs(STARTED)
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(okJson("{\"data\":[]}"))
+                .willSetStateTo("trigger sent")
+        );
+
+        // the trigger POST reaches dbt Cloud (which creates the run) but its response is lost on the wire
+        stubFor(
+            post(urlEqualTo("/api/v2/accounts/123/jobs/456/run/"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":{\"id\":789}}")
+                        .withFixedDelay(1000)
+                )
+        );
+
+        // the confirm-and-adopt lookup after the timeout itself fails: it must never mask the original timeout
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .inScenario("confirm-lookup-fails")
+                .whenScenarioStateIs("trigger sent")
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .willReturn(aResponse().withStatus(500).withHeader("Content-Type", "application/json"))
+        );
+
+        assertThatThrownBy(() -> task.run(runContext))
+            .hasRootCauseInstanceOf(java.net.SocketTimeoutException.class);
+        verify(1, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
+    }
+
+    @Test
+    void testReattachAdoptsAlreadyFinishedRun() throws Exception {
+        TriggerRun task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .jobId(Property.ofValue("456"))
+            .token(Property.ofValue("my-token"))
+            .baseUrl(Property.ofValue("http://localhost:28181"))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        String tag = "[taskrun:" + runContext.taskRunInfo().taskRunId() + "]";
+
+        // this taskrun's run already completed (status 10 = success) before this re-run started
+        stubFor(
+            get(urlPathEqualTo("/api/v2/accounts/123/runs/"))
+                .withQueryParam("job_definition_id", equalTo("456"))
+                .withQueryParam("include_related", matching(".*trigger.*"))
+                .willReturn(okJson("{\"data\":[{\"id\":789,\"status\":10,\"trigger\":{\"cause\":\"Triggered by Kestra. " + tag + "\"}}]}"))
+        );
+
+        TriggerRun.Output output = task.run(runContext);
+
+        assertThat(output.getRunId(), is(789L));
+        verify(0, postRequestedFor(urlEqualTo("/api/v2/accounts/123/jobs/456/run/")));
     }
 }


### PR DESCRIPTION
## Why

`TriggerRun` failed the task when the response to the dbt Cloud job-trigger `POST` was lost on the wire, even though dbt Cloud had received the request, created the run, and ran it to success. That surfaces as a false-positive failure, and the manual re-run that follows creates a duplicate dbt run.

The trigger `POST` is deliberately not retried, since retrying a job-create can start the job twice. So the ambiguity cannot be resolved by retrying. It has to be resolved by looking the run up.

## What

Everything is gated on `reattach = true`. With it off, behavior is unchanged.

### Classifying the failure

New `AbstractDbtCloud.isAmbiguousFailure(Throwable)` answers "may this request already have reached dbt Cloud and created the run?". True for a read timeout, a mid-flight drop, and a 502/504. False for any other HTTP response (a 4xx, a plain 500, a 503), and false for transport failures that never put a byte on the wire (`SSLHandshakeException`, `ConnectException`, `UnknownHostException`, `NoRouteToHostException`). It mirrors the reasoning already in `isRetriableTransientError`.

`AbstractDbtCloud.request(...)` gained an overload taking a caller-supplied `BiPredicate<Throwable, String> retryWhen`, so `TriggerRun` can keep the safe transient retries while excluding ambiguous failures from the generic retry and handling them itself.

### Confirm-and-adopt

On an ambiguous trigger failure, `confirmRunAfterAmbiguousFailure` looks up the run this attempt created, matched by the `[taskrun:<id>]` marker written into the run cause. The lookup is retried 3 times at a 2s constant interval, since a just-created run can take a moment to appear in dbt's run list.

The run is matched in **any** status, so a job that already finished inside the timeout window is adopted and its real outcome reported by `CheckStatus`. If no run is found, the original trigger failure is rethrown unchanged and there is no in-task re-POST.

### Baseline, so a stale run is never adopted

Kestra reuses `taskRunId` across attempts, so the marker alone would match a run left over from a prior attempt. Before the `POST`, the task records a `baseline`: the newest run id of the job. The confirm lookup then requires `id > baseline`, applied server-side with the documented `id__gt` filter and re-checked client-side.

### Widened start-of-run reattach

`findInFlightRun` becomes `findStartOfRunLookup`. It drops the `status__in=[1,2,3]` filter so a run that has already finished is found, and paginates (100 per page) so a busy job does not hide the earlier run behind the first page. It adopts an in-flight or Succeeded run, but never an Error or Cancelled one, so a genuine failure lets a task retry re-trigger rather than re-report the old failure.

### Empty response body

`request(...)` now throws `IOException` on a success status with an empty body, instead of feeding `null` to `MAPPER.readValue` (which throws an opaque `IllegalArgumentException`). Callers that expect a body fail loudly instead of silently writing a `null` artifact, and the trigger `POST` sees it as ambiguous and confirms. This one is not gated on `reattach`.

## Known limitations

Both are documented on the `reattach` property:

- A 503 on the trigger `POST` is still retried internally, since a 503 almost always means the request never reached dbt Cloud. In a rare case it could double-trigger.
- The start-of-run lookup scans a bounded number of pages, so a very busy or heavily shared job that has accumulated a large backlog of runs since this one started may not find the earlier run and could trigger a duplicate.

## Test plan

`./gradlew test --tests "io.kestra.plugin.dbt.cloud.*"` is green (68 passing).

New WireMock tests, each asserting `verify(1, postRequestedFor(...))` so a duplicate trigger fails the test:

- adopt after an ambiguous read timeout, and after a 502/504
- adopt a run that had already finished, and one that finished with a failure
- fail with the original `SocketTimeoutException` when no matching run exists
- fail with the original error when the confirm lookup itself returns a 500, never masking it
- reject a stale run from a prior attempt, and still adopt a lagging new one
- paginate to find a run beyond the first page, on both the confirm and start-of-run paths
- an ambiguous gateway error that created no run is not blindly retried
- an empty trigger response body confirms and adopts
- with `reattach` off, no marker is written, no lookup happens, and the original timeout propagates

- closes: #313
