### PR TITLE
fix(cloud): surface baseUrl as the cause of a 401 on the legacy default host

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -19,12 +19,12 @@ import io.kestra.core.http.client.HttpClientException;
 import io.kestra.core.http.client.HttpClientRequestException;
 import io.kestra.core.http.client.HttpClientResponseException;
 import io.kestra.core.http.client.configurations.HttpConfiguration;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.retrys.Exponential;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.RetryUtils;
-import io.kestra.core.models.annotations.PluginProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -41,10 +41,22 @@ public abstract class AbstractDbtCloud extends Task {
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         .registerModule(new JavaTimeModule());
 
-    @Schema(title = "Base URL to select the tenant")
+    // Legacy shared host. It no longer resolves tokens for regional-cell accounts, whose access URL
+    // instead follows ACCOUNT_PREFIX.REGION.dbt.com. Kept as the default for backward compatibility,
+    // but flagged on a 401 (see request()).
+    private static final String LEGACY_BASE_URL = "https://cloud.getdbt.com";
+
+    @Schema(
+        title = "Base URL to select the tenant",
+        description = """
+            The access URL for your dbt Cloud account. Regional and cell-based accounts use a URL \
+            of the form `ACCOUNT_PREFIX.REGION.dbt.com`, not the legacy `cloud.getdbt.com` host, \
+            which no longer resolves tokens for these accounts and returns a 401 error even with a \
+            valid token."""
+    )
     @NotNull
     @Builder.Default
-    Property<String> baseUrl = Property.ofValue("https://cloud.getdbt.com");
+    Property<String> baseUrl = Property.ofValue(LEGACY_BASE_URL);
 
     @Schema(
         title = "Numeric ID of the account",
@@ -91,6 +103,11 @@ public abstract class AbstractDbtCloud extends Task {
 
         var rMaxRetries = runContext.render(this.maxRetries).as(Integer.class).orElse(3);
         var rInitialDelay = runContext.render(this.initialDelayMs).as(Long.class).orElse(1000L);
+        // The legacy default is still valid for non-regional accounts, so it is not flagged up front.
+        // Only a genuine 401 against it is worth a hint, emitted in the catch below.
+        var usesLegacyBaseUrl = LEGACY_BASE_URL.equals(
+            runContext.render(this.baseUrl).as(String.class).orElse(LEGACY_BASE_URL)
+        );
 
         try (var client = new HttpClient(runContext, options)) {
             return RetryUtils.<HttpResponse<RES>, HttpClientException> of(
@@ -104,14 +121,32 @@ public abstract class AbstractDbtCloud extends Task {
                 (res, throwable) -> isRetriableTransientError(throwable, request.getMethod()),
                 () ->
                 {
-                    var response = client.request(request, String.class);
-                    var parsedResponse = MAPPER.readValue(response.getBody(), responseType);
-                    return HttpResponse.<RES> builder()
-                        .request(request)
-                        .body(parsedResponse)
-                        .headers(response.getHeaders())
-                        .status(response.getStatus())
-                        .build();
+                    try {
+                        var response = client.request(request, String.class);
+                        var parsedResponse = MAPPER.readValue(response.getBody(), responseType);
+                        return HttpResponse.<RES> builder()
+                            .request(request)
+                            .body(parsedResponse)
+                            .headers(response.getHeaders())
+                            .status(response.getStatus())
+                            .build();
+                    } catch (HttpClientResponseException e) {
+                        // A 401 against the legacy default host is almost always a wrong baseUrl, not a bad
+                        // token: the shared host no longer resolves tokens for regional and cell-based
+                        // accounts. Rethrow the same type with an enriched message so the failure itself
+                        // names baseUrl, keeping the original 401 as the cause. Other cases pass through.
+                        if (usesLegacyBaseUrl && e.getResponse().getStatus().getCode() == 401) {
+                            throw new HttpClientResponseException(
+                                "Received a 401 while using the legacy baseUrl default \"" + LEGACY_BASE_URL +
+                                    "\". This host no longer resolves tokens for regional and cell-based dbt " +
+                                    "Cloud accounts. Before checking the token, set baseUrl to your account's " +
+                                    "access URL (ACCOUNT_PREFIX.REGION.dbt.com). Original error: " + e.getMessage(),
+                                e.getResponse(),
+                                e
+                            );
+                        }
+                        throw e;
+                    }
                 }
             );
         }
@@ -120,7 +155,8 @@ public abstract class AbstractDbtCloud extends Task {
     /**
      * Whether an error calling the dbt Cloud API is transient and worth retrying.
      *
-     * <p>Read-only methods (GET/HEAD) retry any transient signal: all 5xx, connection failures and
+     * <p>
+     * Read-only methods (GET/HEAD) retry any transient signal: all 5xx, connection failures and
      * timeouts. Other methods retry only the 502/503/504 gateway errors plus transport failures that
      * provably never reached dbt Cloud (TLS handshake, connection refused). A plain 500, a read timeout
      * or a mid-flight connection drop is not retried for them, since the request may already have
@@ -129,7 +165,8 @@ public abstract class AbstractDbtCloud extends Task {
      * any method, since dbt Cloud rejects it before running the request. Other client errors (4xx) are
      * never retried.
      *
-     * <p>The core HTTP client wraps a read timeout as {@code RuntimeException(SocketTimeoutException)},
+     * <p>
+     * The core HTTP client wraps a read timeout as {@code RuntimeException(SocketTimeoutException)},
      * so it is matched through the cause.
      */
     static boolean isRetriableTransientError(Throwable throwable, String method) {

--- a/src/test/java/io/kestra/plugin/dbt/cloud/LegacyBaseUrlWarningTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/LegacyBaseUrlWarningTest.java
@@ -1,0 +1,131 @@
+package io.kestra.plugin.dbt.cloud;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.http.HttpResponse;
+import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.http.client.HttpClientResponseException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for issue #317: a 401 against the legacy default baseUrl
+ * (https://cloud.getdbt.com) must fail with a message pointing at baseUrl instead of only
+ * suggesting a bad token, since that host no longer resolves tokens for regional and
+ * cell-based dbt Cloud accounts.
+ */
+@KestraTest
+class LegacyBaseUrlWarningTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    private static HttpClientResponseException unauthorized() {
+        return new HttpClientResponseException(
+            "status 401",
+            HttpResponse.<String> builder()
+                .status(HttpResponse.Status.builder().code(401).build())
+                .build()
+        );
+    }
+
+    @Test
+    void shouldSurfaceBaseUrlGuidanceOn401AgainstLegacyDefault() throws Exception {
+        var task = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .runId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .accountId(Property.ofValue("fake-account"))
+            // baseUrl left unset: resolves to the legacy default https://cloud.getdbt.com
+            .maxRetries(Property.ofValue(1))
+            .initialDelayMs(Property.ofValue(10L))
+            .build();
+
+        var runContext = mockRunContext(task);
+        var requestBuilder = HttpRequest.builder()
+            .uri(new URI("https://cloud.getdbt.com/api/v2/accounts/fake-account/runs/123/"))
+            .method("GET");
+
+        try (
+            var mocked = Mockito.mockConstruction(
+                HttpClient.class,
+                (mockClient, context) -> when(mockClient.request(any(HttpRequest.class), eq(String.class)))
+                    .thenThrow(unauthorized())
+            )
+        ) {
+            var ex = assertThrows(
+                HttpClientResponseException.class,
+                () -> task.request(runContext, requestBuilder, Object.class)
+            );
+
+            // The 401 still fails the task, but now names baseUrl as the likely cause.
+            assertThat(ex.getResponse().getStatus().getCode(), is(401));
+            assertThat(ex.getMessage(), containsString("Received a 401"));
+            assertThat(ex.getMessage(), containsString("baseUrl"));
+        }
+    }
+
+    @Test
+    void shouldNotAddBaseUrlGuidanceOn401AgainstCustomBaseUrl() throws Exception {
+        var task = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .baseUrl(Property.ofValue("https://my-account.us1.dbt.com"))
+            .runId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .accountId(Property.ofValue("fake-account"))
+            .maxRetries(Property.ofValue(1))
+            .initialDelayMs(Property.ofValue(10L))
+            .build();
+
+        var runContext = mockRunContext(task);
+        var requestBuilder = HttpRequest.builder()
+            .uri(new URI("https://my-account.us1.dbt.com/api/v2/accounts/fake-account/runs/123/"))
+            .method("GET");
+
+        try (
+            var mocked = Mockito.mockConstruction(
+                HttpClient.class,
+                (mockClient, context) -> when(mockClient.request(any(HttpRequest.class), eq(String.class)))
+                    .thenThrow(unauthorized())
+            )
+        ) {
+            var ex = assertThrows(
+                HttpClientResponseException.class,
+                () -> task.request(runContext, requestBuilder, Object.class)
+            );
+
+            // A 401 against a custom baseUrl is left untouched: the original error passes through.
+            assertThat(ex.getResponse().getStatus().getCode(), is(401));
+            assertThat(ex.getMessage(), not(containsString("baseUrl")));
+            assertThat(ex.getMessage(), not(containsString("Received a 401")));
+        }
+    }
+
+    private RunContext mockRunContext(CheckStatus task) {
+        var flow = TestsUtils.mockFlow();
+        var execution = TestsUtils.mockExecution(flow, java.util.Map.of(), null);
+        var taskRun = TestsUtils.mockTaskRun(execution, task);
+        return runContextFactory.of(flow, task, execution, taskRun, false);
+    }
+}


### PR DESCRIPTION
dbt Cloud tasks that leave `baseUrl` at the legacy default `https://cloud.getdbt.com` fail with a bare `401 Invalid token`, which points users at their credentials. That host no longer resolves tokens for regional and cell-based accounts, whose access URL follows `ACCOUNT_PREFIX.REGION.dbt.com` (Account Settings > Account Information). Both personal access tokens and service tokens fail identically, so the debugging stays on the token for a long time.

## Changes

- On a `401` against the legacy default host, log a hint naming `baseUrl` as the likely cause, then rethrow the original error so the task still fails. A `401` against a custom `baseUrl` is left untouched, since there it really is a token problem.
- Expand the `baseUrl` schema description to explain the regional access URL requirement and where to find it.

Non-breaking: the default value is kept. Making `baseUrl` required is a separate future change that needs a deprecation cycle.

## Test

`LegacyBaseUrlWarningTest` covers both paths: legacy default plus a mocked 401 surfaces the `baseUrl` hint and still fails with a 401, and a custom `baseUrl` plus a 401 adds no hint.

- closes: #317