### PR TITLE
fix(cloud): emit per-model taskruns on failed dbt Cloud runs

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/CheckStatus.java
@@ -18,6 +18,7 @@ import io.kestra.core.http.client.HttpClientException;
 import io.kestra.core.http.client.HttpClientResponseException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -40,7 +41,6 @@ import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwSupplier;
 import static java.lang.Math.max;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -71,9 +71,9 @@ import io.kestra.core.models.annotations.PluginProperty;
 )
 public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckStatus.Output> {
     private static final Set<JobStatus> ENDED_STATUS = Set.of(
-        JobStatus.NUMBER_10,  // Success
-        JobStatus.NUMBER_20,  // Error
-        JobStatus.NUMBER_30   // Cancelled
+        JobStatus.NUMBER_10, // Success
+        JobStatus.NUMBER_20, // Error
+        JobStatus.NUMBER_30 // Cancelled
     );
 
     @Schema(
@@ -170,39 +170,52 @@ public class CheckStatus extends AbstractDbtCloud implements RunnableTask<CheckS
         // final response
         logSteps(logger, finalRunResponse);
 
-        if (!isSuccessful(finalRunResponse.getData())) {
+        boolean successful = isSuccessful(finalRunResponse.getData());
+
+        // Download and parse artifacts before failing on a non-successful run: dbt Cloud saves
+        // run_results.json for failed runs too, and parseRunResult is what emits the per-model
+        // dynamic taskruns/logs (issue #315) — those must land even though the task ends up throwing.
+        URI runResultsUri = null;
+        URI manifestUri = null;
+        try {
+            // Artifacts are uploaded asynchronously by dbt Cloud and manifest.json is absent for some
+            // run shapes (e.g. dbt source freshness). Tolerate 404 so a legitimate success is not
+            // reported as a failure.
+            Path runResultsArtifact = downloadArtifacts(runContext, runIdRendered, "run_results.json", RunResult.class);
+            Path manifestArtifact = downloadArtifacts(runContext, runIdRendered, "manifest.json", ManifestArtifact.class);
+
+            io.kestra.plugin.dbt.models.Manifest manifest = null;
+            if (manifestArtifact != null) {
+                ResultParser.ManifestResult manifestResult = ResultParser.parseManifestWithAssets(runContext, manifestArtifact.toFile());
+                manifest = manifestResult.manifest();
+                manifestUri = manifestResult.uri();
+            }
+
+            if (runResultsArtifact != null) {
+                if (runContext.render(this.parseRunResults).as(Boolean.class).orElse(false)) {
+                    runResultsUri = ResultParser.parseRunResult(runContext, runResultsArtifact.toFile(), manifest);
+                } else {
+                    runResultsUri = runContext.storage().putFile(runResultsArtifact.toFile());
+                }
+            }
+        } catch (Exception e) {
+            if (successful) {
+                // On a successful run, a broken artifact download/parse is the only failure and must surface.
+                throw e;
+            }
+            logger.warn("Unable to download or parse artifacts for failed run '{}': {}", runIdRendered, e.getMessage(), e);
+        }
+
+        if (!successful) {
             throw new Exception(
                 "Failed run with status '" + finalRunResponse.getData().getStatusHumanized() +
                     "' after " + finalRunResponse.getData().getDurationHumanized() +
                     (finalRunResponse.getData().getStatusMessage() != null
                         ? ": " + finalRunResponse.getData().getStatusMessage()
-                        : "") +
+                        : "")
+                    +
                     ": " + finalRunResponse
             );
-        }
-
-        // Artifacts are uploaded asynchronously by dbt Cloud and manifest.json is absent for some
-        // run shapes (e.g. dbt source freshness). Tolerate 404 so a legitimate success is not
-        // reported as a failure.
-        Path runResultsArtifact = downloadArtifacts(runContext, runIdRendered, "run_results.json", RunResult.class);
-        Path manifestArtifact = downloadArtifacts(runContext, runIdRendered, "manifest.json", ManifestArtifact.class);
-
-        io.kestra.plugin.dbt.models.Manifest manifest = null;
-        URI manifestUri = null;
-        if (manifestArtifact != null) {
-            ResultParser.ManifestResult manifestResult = ResultParser.parseManifestWithAssets(runContext, manifestArtifact.toFile());
-            manifest = manifestResult.manifest();
-            manifestUri = manifestResult.uri();
-        }
-
-        URI runResultsUri = null;
-
-        if (runResultsArtifact != null) {
-            if (runContext.render(this.parseRunResults).as(Boolean.class).orElse(false)) {
-                runResultsUri = ResultParser.parseRunResult(runContext, runResultsArtifact.toFile(), manifest);
-            } else {
-                runResultsUri = runContext.storage().putFile(runResultsArtifact.toFile());
-            }
         }
 
         return Output.builder()

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CheckStatusTest.java
@@ -13,11 +13,13 @@ import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import io.kestra.core.http.client.HttpClientResponseException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 
@@ -28,6 +30,7 @@ import reactor.core.publisher.Flux;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -242,6 +245,96 @@ class CheckStatusTest {
 
         var ex = assertThrows(Exception.class, () -> checkStatus.run(runContext));
         assertThat(ex.getMessage(), containsString("Compilation failed in step 1"));
+    }
+
+    /**
+     * Regression test for issue #315: on a FAILED run, dbt Cloud still saves run_results.json, and
+     * the task must download/parse it (emitting per-model dynamic taskruns and logs) before failing,
+     * instead of throwing immediately and leaving the failed models with no per-node visibility.
+     */
+    @Test
+    void shouldEmitModelTaskRunsOnFailedRunBeforeThrowing() throws Exception {
+        stubFor(
+            get(urlMatching("/api/v2/accounts/123/runs/6667/\\?.*"))
+                .willReturn(okJson("""
+                        {
+                          "data": {
+                            "id": 6667,
+                            "status": 20,
+                            "status_humanized": "Error",
+                            "status_message": "Model failed",
+                            "duration_humanized": "5s",
+                            "run_steps": []
+                          }
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/6667/artifacts/run_results.json"))
+                .willReturn(okJson("""
+                        {
+                          "metadata": {"dbt_version": "1.8.0"},
+                          "results": [
+                            {
+                              "status": "error",
+                              "message": "Database Error in model fct_orders",
+                              "failures": 1,
+                              "unique_id": "model.my_project.fct_orders",
+                              "execution_time": 0.13,
+                              "adapter_response": {},
+                              "timing": [
+                                {"name": "compile", "started_at": "2024-01-01T00:00:00Z", "completed_at": "2024-01-01T00:00:01Z"},
+                                {"name": "execute", "started_at": "2024-01-01T00:00:01Z", "completed_at": "2024-01-01T00:00:02Z"}
+                              ]
+                            }
+                          ],
+                          "elapsed_time": 0.13
+                        }
+                    """))
+        );
+
+        stubFor(
+            get(urlEqualTo("/api/v2/accounts/123/runs/6667/artifacts/manifest.json"))
+                .willReturn(aResponse().withStatus(404).withBody("Not Found"))
+        );
+
+        CheckStatus checkStatus = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .baseUrl(Property.ofValue("http://localhost:8089"))
+            .runId(Property.ofValue("6667"))
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue("fake-token"))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .parseRunResults(Property.ofValue(true))
+            .build();
+
+        RunContext runContext = mockRunContext(checkStatus);
+
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+
+        // The run failed — the task must still throw, carrying the same message as before the fix.
+        var ex = assertThrows(Exception.class, () -> checkStatus.run(runContext));
+        assertThat(ex.getMessage(), containsString("Model failed"));
+
+        // But run_results.json must have been downloaded and parsed regardless, emitting a dynamic
+        // taskrun for the failed model with an ERROR state — this is what was missing before the fix.
+        List<WorkerTaskResult> modelTaskRuns = runContext.dynamicWorkerResults();
+        assertThat(modelTaskRuns, hasSize(1));
+        assertThat(modelTaskRuns.getFirst().getTaskRun().getTaskId(), is("model.my_project.fct_orders"));
+        assertThat(modelTaskRuns.getFirst().getTaskRun().getState().getCurrent(), is(State.Type.FAILED));
+
+        // And its failure message must have been logged under that model's own dynamic taskrun.
+        String modelTaskRunId = modelTaskRuns.getFirst().getTaskRun().getId();
+        TestsUtils.awaitLog(logs, l -> l.getTaskRunId() != null && l.getTaskRunId().equals(modelTaskRunId));
+        receive.blockLast();
+
+        assertThat(
+            logs.stream().anyMatch(l -> modelTaskRunId.equals(l.getTaskRunId()) && l.getMessage().contains("Database Error")),
+            is(true)
+        );
     }
 
     /**
@@ -562,10 +655,12 @@ class CheckStatusTest {
             get(urlMatching("/api/v2/accounts/123/runs/9090/\\?.*"))
                 .inScenario("transient-then-success")
                 .whenScenarioStateIs(Scenario.STARTED)
-                .willReturn(aResponse()
-                    .withStatus(500)
-                    .withHeader("Content-Type", "text/html")
-                    .withBody("<html><title>Uh oh! | dbt</title></html>"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody("<html><title>Uh oh! | dbt</title></html>")
+                )
                 .willSetStateTo("recovered")
         );
 


### PR DESCRIPTION
`CheckStatus`/`TriggerRun` with `wait: true` emitted per-model dynamic taskruns, their logs and dbt's own timings only when the dbt run succeeded. On a failed run they were absent, because the failure `throw` in `CheckStatus.run` ran before the artifact download and `run_results.json` parsing that emits them. dbt Cloud stores `run_results.json` for failed runs too, so the data was there. The user was left with raw log lines under one task instead of per-node taskruns showing which models errored.

## Change

- Download and parse artifacts (which emits the per-model taskruns via `dynamicWorkerResult`) before the failure check.
- Wrap that block so an artifact or parse error on a failed run is logged and swallowed, never masking the real dbt failure. On a successful run a parse error still propagates, as before.
- The failure exception and its message are unchanged. `Output` is still only returned on success.
- `TriggerRun` with `wait: true` benefits through the same path, since it delegates to `CheckStatus.run`.

## Known follow-ups (edge cases, not addressed here)

- A task-level `retry:` on a genuinely failed run now re-downloads artifacts and re-emits a fresh set of per-model taskruns each attempt, instead of the previous cheap no-op.
- If `parseRunResult` throws partway through the model list on a failed run, the taskruns emitted so far stay and the rest are dropped with only a warning.

## Test

`CheckStatusTest.shouldEmitModelTaskRunsOnFailedRunBeforeThrowing`: a failed run status plus an available `run_results.json` asserts the task still throws and a per-model taskrun (state FAILED) with its error log is emitted.

- closes: #315