### PR TITLE
fix(dbt): keep a node with no dbt timings from breaking its taskrun

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/ResultParser.java
+++ b/src/main/java/io/kestra/plugin/dbt/ResultParser.java
@@ -62,6 +62,9 @@ public abstract class ResultParser {
 
         Map<String, ModelAsset> modelAssets = manifest == null ? Map.of() : extractAssetNodes(manifest);
 
+        // Anchor for nodes dbt never ran, which carry no timings of their own.
+        Instant generatedAt = result.getMetadata() == null ? null : result.getMetadata().getGeneratedAt();
+
         // Emit one dynamic taskrun per dbt model (the UI timeline "bars"), attaching that model's
         // own status/message/failures as logs riding with its taskrun so they render inline under
         // its bar instead of all landing on the parent task root (issue #276).
@@ -70,55 +73,9 @@ public abstract class ResultParser {
             .stream()
             .forEach(throwConsumer(r ->
             {
-                ArrayList<State.History> histories = new ArrayList<>();
-
-                // List of status are not safe and can be not present on api calls
-                r.getTiming()
-                    .stream()
-                    .mapToLong(timing -> timing.getStartedAt().toEpochMilli())
-                    .min()
-                    .ifPresent(value ->
-                    {
-                        histories.add(
-                            new State.History(
-                                State.Type.CREATED,
-                                Instant.ofEpochMilli(value)
-                            )
-                        );
-                    });
-
-                r.getTiming()
-                    .stream()
-                    .filter(timing -> timing.getName().equals("execute"))
-                    .mapToLong(timing -> timing.getStartedAt().toEpochMilli())
-                    .min()
-                    .ifPresent(value ->
-                    {
-                        histories.add(
-                            new State.History(
-                                State.Type.RUNNING,
-                                Instant.ofEpochMilli(value)
-                            )
-                        );
-                    });
-
-                r.getTiming()
-                    .stream()
-                    .mapToLong(timing -> timing.getCompletedAt().toEpochMilli())
-                    .max()
-                    .ifPresent(value ->
-                    {
-                        histories.add(
-                            new State.History(
-                                r.state(),
-                                Instant.ofEpochMilli(value)
-                            )
-                        );
-                    });
-
                 State state = State.of(
                     r.state(),
-                    histories
+                    historiesFor(r, generatedAt)
                 );
 
                 r.getAdapterResponse()
@@ -165,6 +122,57 @@ public abstract class ResultParser {
             }));
 
         return runContext.storage().putFile(file);
+    }
+
+    /**
+     * Build a model taskrun's state history from dbt's own timings, so the UI timeline shows when dbt ran
+     * the node rather than when Kestra materialized the taskrun.
+     *
+     * <p>
+     * dbt leaves {@code timing} empty for a node it never ran: a skipped model, or one that failed before
+     * it compiled. There is no per-node instant to use then, so the history is anchored on the run's
+     * {@code generated_at} and spans the node's {@code execution_time}, which is 0 for a skipped node.
+     * An empty history is not an option, since {@link State#getStartDate()} reads the first entry and
+     * throws on an empty one, taking the whole run down with it.
+     */
+    static List<State.History> historiesFor(RunResult.Result r, Instant generatedAt) {
+        List<RunResult.Timing> timings = r.getTiming() == null ? List.of() : r.getTiming();
+
+        ArrayList<State.History> histories = new ArrayList<>();
+
+        // The timings themselves are not safe either: they can be absent on api calls.
+        timings.stream()
+            .map(RunResult.Timing::getStartedAt)
+            .filter(Objects::nonNull)
+            .min(Instant::compareTo)
+            .ifPresent(value -> histories.add(new State.History(State.Type.CREATED, value)));
+
+        timings.stream()
+            .filter(timing -> "execute".equals(timing.getName()))
+            .map(RunResult.Timing::getStartedAt)
+            .filter(Objects::nonNull)
+            .min(Instant::compareTo)
+            .ifPresent(value -> histories.add(new State.History(State.Type.RUNNING, value)));
+
+        timings.stream()
+            .map(RunResult.Timing::getCompletedAt)
+            .filter(Objects::nonNull)
+            .max(Instant::compareTo)
+            .ifPresent(value -> histories.add(new State.History(r.state(), value)));
+
+        if (!histories.isEmpty()) {
+            return histories;
+        }
+
+        Instant end = generatedAt != null ? generatedAt : Instant.now();
+        long executionMillis = r.getExecutionTime() == null ? 0L : Math.round(r.getExecutionTime() * 1000);
+        Instant start = end.minusMillis(executionMillis);
+
+        return List.of(
+            new State.History(State.Type.CREATED, start),
+            new State.History(State.Type.RUNNING, start),
+            new State.History(r.state(), end)
+        );
     }
 
     /**

--- a/src/main/java/io/kestra/plugin/dbt/models/RunResult.java
+++ b/src/main/java/io/kestra/plugin/dbt/models/RunResult.java
@@ -18,10 +18,22 @@ import lombok.extern.jackson.Jacksonized;
 public class RunResult {
     List<Result> results;
 
+    Metadata metadata;
+
     @JsonProperty("elapsed_time")
     Double elapsedTime;
 
     Map<String, Object> args;
+
+    @Value
+    @Jacksonized
+    @SuperBuilder
+    public static class Metadata {
+        // When dbt wrote run_results.json. Used as the anchor for a node dbt never ran, which carries
+        // no timings of its own.
+        @JsonProperty("generated_at")
+        Instant generatedAt;
+    }
 
     @Value
     @Jacksonized

--- a/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
@@ -1,6 +1,8 @@
 package io.kestra.plugin.dbt;
 
 import java.nio.file.Files;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -13,6 +15,7 @@ import org.slf4j.event.Level;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
@@ -490,4 +493,64 @@ class ResultParserTest {
         var taskRun = TestsUtils.mockTaskRun(execution, task);
         return runContextFactory.of(flow, task, execution, taskRun, false);
     }
+
+    @Test
+    void parseRunResult_shouldNotFailOnANodeWithNoTimings() throws Exception {
+        var runContext = mockRunContext();
+        var runResultsFile = runContext.workingDir().path(true).resolve("run_results.json");
+        // dbt emits an empty `timing` for a node it never ran: a skipped model, or one that failed
+        // before it compiled. Its taskrun must still carry a usable state history.
+        Files.writeString(runResultsFile, """
+            {
+              "metadata": {
+                "dbt_version": "1.8.0",
+                "generated_at": "2024-01-01T00:00:10Z"
+              },
+              "results": [
+                {
+                  "status": "skipped",
+                  "message": null,
+                  "failures": null,
+                  "unique_id": "model.my_project.downstream",
+                  "execution_time": 0.0,
+                  "adapter_response": {},
+                  "timing": []
+                },
+                {
+                  "status": "success",
+                  "message": "CREATE VIEW",
+                  "failures": null,
+                  "unique_id": "model.my_project.stg_orders",
+                  "execution_time": 0.42,
+                  "adapter_response": {},
+                  "timing": [
+                    {"name": "compile", "started_at": "2024-01-01T00:00:00Z", "completed_at": "2024-01-01T00:00:01Z"},
+                    {"name": "execute", "started_at": "2024-01-01T00:00:01Z", "completed_at": "2024-01-01T00:00:02Z"}
+                  ]
+                }
+              ],
+              "elapsed_time": 1.23
+            }
+            """);
+
+        ResultParser.parseRunResult(runContext, runResultsFile.toFile(), null);
+
+        Map<String, TaskRun> byNode = runContext.dynamicWorkerResults().stream()
+            .map(WorkerTaskResult::getTaskRun)
+            .collect(Collectors.toMap(TaskRun::getTaskId, t -> t));
+        assertThat(byNode.keySet(), hasSize(2));
+
+        // the skipped node: reading its dates must not throw, and it is anchored on the run's generated_at
+        var skipped = byNode.get("model.my_project.downstream").getState();
+        assertThat(skipped.getCurrent(), is(State.Type.SKIPPED));
+        assertThat(skipped.getStartDate(), is(Instant.parse("2024-01-01T00:00:10Z")));
+        assertThat(skipped.getDuration(), is(java.util.Optional.of(Duration.ZERO)));
+
+        // the node dbt did run still reports dbt's own timings, not Kestra's materialization time
+        var ran = byNode.get("model.my_project.stg_orders").getState();
+        assertThat(ran.getStartDate(), is(Instant.parse("2024-01-01T00:00:00Z")));
+        assertThat(ran.getEndDate(), is(java.util.Optional.of(Instant.parse("2024-01-01T00:00:02Z"))));
+        assertThat(ran.getDuration(), is(java.util.Optional.of(Duration.ofSeconds(2))));
+    }
+
 }


### PR DESCRIPTION
## Why

Investigating #316 turned up a different, harder failure in the same code.

dbt leaves `timing` empty for a node it never ran: a skipped model, or one that failed before it compiled. `ResultParser` built the per-model taskrun's state history entirely from those timings, so such a node ended up with an empty history. `State.getStartDate()` reads `histories.getFirst()`, so reading the taskrun's dates threw `NoSuchElementException`, which happens when the taskrun is serialized.

Any dbt run containing a skipped node hits this, and `RunResult.Result.state()` already maps `"skipped"` explicitly, so skipped nodes are expected to reach here.

## What

- A node with no timings is anchored on the run's `generated_at` and spans its own `execution_time`, which is 0 for a skipped node. The history is never empty.
- `metadata.generated_at` is now modelled on `RunResult` to provide that anchor. It falls back to now if absent.
- The individual timings are null-checked, since the existing comment already notes they are not guaranteed on api calls, and `getStartedAt()` / `getCompletedAt()` were dereferenced unguarded.
- Nodes dbt actually ran are unchanged and still carry dbt's own timestamps.

## On #316 itself

The reported cause does not hold, and I would not close #316 with this.

`ResultParser` already builds each taskrun's CREATED / RUNNING / terminal history from dbt's own `timing[]` `started_at` and `completed_at`, and `WorkerTaskProcessor.dynamicWorkerResults` only sets `dynamic(true)`, so those timestamps reach the executor untouched. Measured with a fixture carrying a 2s span, the taskrun reports `PT2S`.

The likely explanation for the report is that `execution_time` (0.09s) and the timing span (0.048s) are different measurements, since `execution_time` includes overhead outside the compile and execute phases. Confirming that needs the `run_results.json` from execution `1sVcFM8pmhT0CoX6lhwwI9`.

What is arguably still worth doing for #316 is surfacing `execution_time` and the per-phase `timing[]` entries as taskrun metadata, which is a smaller and different change than the title implies.

## Test plan

`./gradlew test --tests "io.kestra.plugin.dbt.ResultParserTest" --tests "io.kestra.plugin.dbt.cloud.*"` is green, 76 passing.

New test `parseRunResult_shouldNotFailOnANodeWithNoTimings` covers a run mixing a skipped node with an executed one, and asserts the skipped node's dates are readable and anchored on `generated_at`, and that the executed node still reports dbt's own timings.

- part-of: #316
