### PR TITLE
fix(dbt): ignore unknown keys under manifest depends_on

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/ResultParser.java
+++ b/src/main/java/io/kestra/plugin/dbt/ResultParser.java
@@ -49,8 +49,19 @@ public abstract class ResultParser {
     }
 
     public static ManifestResult parseManifestWithAssets(RunContext runContext, File file) throws IOException, IllegalVariableEvaluationException {
-        Manifest manifest = MAPPER.readValue(file, Manifest.class);
-        emitAssets(runContext, manifest);
+        Manifest manifest = null;
+
+        // Asset lineage is metadata about the run, not the run itself. dbt adds fields to the
+        // manifest between schema versions, so a manifest this plugin cannot map must not turn a
+        // successful dbt run into a failed task. Store the raw file and carry on without assets.
+        try {
+            manifest = MAPPER.readValue(file, Manifest.class);
+            emitAssets(runContext, manifest);
+        } catch (Exception e) {
+            manifest = null;
+            runContext.logger().warn("Unable to read the dbt manifest, assets will not be emitted. The manifest is still stored as an output file.", e);
+        }
+
         return new ManifestResult(manifest, runContext.storage().putFile(file));
     }
 
@@ -289,8 +300,8 @@ public abstract class ResultParser {
                 List<String> dependsOn;
                 if (manifest.getParentMap() != null && manifest.getParentMap().containsKey(uniqueId)) {
                     dependsOn = manifest.getParentMap().get(uniqueId);
-                } else if (node.getDependsOn() != null) {
-                    dependsOn = node.getDependsOn().getOrDefault("nodes", List.of());
+                } else if (node.getDependsOn() != null && node.getDependsOn().getNodes() != null) {
+                    dependsOn = node.getDependsOn().getNodes();
                 } else {
                     dependsOn = List.of();
                 }

--- a/src/main/java/io/kestra/plugin/dbt/models/Manifest.java
+++ b/src/main/java/io/kestra/plugin/dbt/models/Manifest.java
@@ -40,11 +40,24 @@ public class Manifest {
         @JsonProperty("resource_type")
         String resourceType;
 
+        // Typed rather than a raw Map: dbt adds keys under `depends_on` between manifest
+        // schema versions (e.g. `nodes_with_ref_location`, whose values are arrays, not
+        // strings). Naming only what we read lets unknown keys be ignored instead of
+        // failing the whole parse.
         @JsonProperty("depends_on")
-        Map<String, List<String>> dependsOn;
+        DependsOn dependsOn;
 
         @JsonProperty("unique_id")
         String uniqueId;
+    }
+
+    @Value
+    @Jacksonized
+    @SuperBuilder
+    public static class DependsOn {
+        List<String> nodes;
+
+        List<String> macros;
     }
 
     @Value

--- a/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/ResultParserTest.java
@@ -328,6 +328,110 @@ class ResultParserTest {
     }
 
     @Test
+    void parseManifestWithAssets_shouldIgnoreUnknownDependsOnKeys() throws Exception {
+        var runContext = mockRunContext();
+        var manifestFile = runContext.workingDir().path(true).resolve("manifest.json");
+        // dbt adds keys under `depends_on` between manifest schema versions. `nodes_with_ref_location`
+        // holds arrays, not strings: reading it must not break lineage for the keys we do use.
+        Files.writeString(manifestFile, """
+            {
+              "metadata": {
+                "adapter_type": "postgres"
+              },
+              "nodes": {
+                "model.analytics.parent": {
+                  "resource_type": "model",
+                  "database": "analytics",
+                  "schema": "marts",
+                  "name": "parent",
+                  "unique_id": "model.analytics.parent",
+                  "depends_on": {
+                    "macros": [],
+                    "nodes": [],
+                    "nodes_with_ref_location": []
+                  }
+                },
+                "model.analytics.child": {
+                  "resource_type": "model",
+                  "database": "analytics",
+                  "schema": "marts",
+                  "name": "child",
+                  "unique_id": "model.analytics.child",
+                  "depends_on": {
+                    "macros": [],
+                    "nodes": ["model.analytics.parent"],
+                    "nodes_with_ref_location": [
+                      ["model.analytics.parent", {"file": "models/child.sql", "line": 3}]
+                    ]
+                  }
+                }
+              }
+            }
+            """);
+
+        var manifestResult = ResultParser.parseManifestWithAssets(runContext, manifestFile.toFile());
+
+        assertThat(manifestResult.manifest(), is(notNullValue()));
+        assertThat(runContext.assets().emitted(), hasSize(2));
+
+        // depends_on.nodes is still read (no parent_map here), so the edge survives the unknown key.
+        var childEmit = findEmitWithOutput(runContext.assets().emitted(), "analytics.marts.child");
+        assertThat(childEmit, is(notNullValue()));
+        assertThat(childEmit.inputs(), hasSize(1));
+        assertThat(childEmit.inputs().getFirst().id(), is("analytics.marts.parent"));
+    }
+
+    @Test
+    void parseManifestWithAssets_shouldStoreTheManifestFileUntouched() throws Exception {
+        var runContext = mockRunContext();
+        var manifestFile = runContext.workingDir().path(true).resolve("manifest.json");
+        // The Manifest POJO drops keys it does not declare. The stored artifact must not: it is the
+        // file users download, so it has to stay byte-for-byte what dbt wrote.
+        var original = """
+            {
+              "nodes": {
+                "model.p.child": {
+                  "unique_id": "model.p.child",
+                  "resource_type": "model",
+                  "database": "db",
+                  "schema": "s",
+                  "name": "child",
+                  "depends_on": {
+                    "nodes": ["model.p.parent"],
+                    "nodes_with_ref_location": [["model.p.parent", {"file": "models/child.sql", "line": 3}]],
+                    "some_future_key": ["anything"]
+                  }
+                }
+              }
+            }
+            """;
+        Files.writeString(manifestFile, original);
+
+        var manifestResult = ResultParser.parseManifestWithAssets(runContext, manifestFile.toFile());
+
+        // putFile stores a copy and deletes the local file, so read it back from internal storage:
+        // the bytes must be what dbt wrote, undeclared keys and all.
+        var stored = new String(runContext.storage().getFile(manifestResult.uri()).readAllBytes());
+        assertThat(stored, is(original));
+        assertThat(stored, containsString("nodes_with_ref_location"));
+        assertThat(stored, containsString("some_future_key"));
+    }
+
+    @Test
+    void parseManifestWithAssets_shouldStoreManifestWhenItCannotBeRead() throws Exception {
+        var runContext = mockRunContext();
+        var manifestFile = runContext.workingDir().path(true).resolve("manifest.json");
+        // An unreadable manifest is metadata we lose, not a reason to fail a dbt run that succeeded.
+        Files.writeString(manifestFile, "{ this is not json");
+
+        var manifestResult = ResultParser.parseManifestWithAssets(runContext, manifestFile.toFile());
+
+        assertThat(manifestResult.manifest(), is(nullValue()));
+        assertThat(manifestResult.uri(), is(notNullValue()));
+        assertThat(runContext.assets().emitted(), hasSize(0));
+    }
+
+    @Test
     void parseRunResult_shouldEmitModelLogsUnderDynamicTaskRuns() throws Exception {
         var runContext = mockRunContext();
         var runResultsFile = runContext.workingDir().path(true).resolve("run_results.json");


### PR DESCRIPTION
### What

`Manifest.Node.dependsOn` was `Map<String, List<String>>`, which tells Jackson that every key under `depends_on` holds a list of strings, including keys we have never seen. dbt's Fusion engine writes a third one:

```rust
// dbt-core, crates/dbt-schemas/src/schemas/common.rs
pub struct NodeDependsOn {
    pub macros: Vec<String>,
    pub nodes: Vec<String>,
    pub nodes_with_ref_location: Vec<(String, CodeLocationWithFile)>,
}
```

A Rust tuple serializes as a JSON array, so the value is a list of arrays. Jackson has to bind every key of a typed `Map`, so it died on a field the plugin never reads:

```
Cannot deserialize value of type `java.lang.String` from Array value
 ... ["depends_on"] -> LinkedHashMap["nodes_with_ref_location"] -> ArrayList[0]
```

On the dbt Cloud path the dbt job had already succeeded, so `CheckStatus` rethrew and the execution went red with downstream tasks blocked.

Two changes:

1. Declare the two fields we read instead of typing the container. Unknown keys then fall through the mapper's existing `FAIL_ON_UNKNOWN_PROPERTIES=false` and are dropped unread, so future dbt additions cost nothing.
2. Stop letting a manifest we cannot read fail the task. dbt's published schema (`manifest/v12.json`) still declares only `macros` and `nodes` with `additionalProperties: false`, and v13 does not exist, so the schema does not track what the engine emits and this will recur. A manifest that fails to parse now logs a warning, is still stored as an output file, and the task reports the real dbt outcome without asset lineage.

Only `depends_on.nodes` is ever read, and only as a fallback when `parent_map` is missing, so nothing else changes.

### How to test

```
./gradlew test --tests 'io.kestra.plugin.dbt.ResultParserTest'
```

Three tests added:

- `shouldIgnoreUnknownDependsOnKeys` parses a manifest containing `nodes_with_ref_location` and asserts lineage still resolves. Fails without change 1.
- `shouldStoreManifestWhenItCannotBeRead` feeds unparseable JSON and asserts no throw, null manifest, URI present. Fails without change 2.
- `shouldStoreTheManifestFileUntouched` reads the stored artifact back and asserts the bytes still contain the undeclared keys, so narrowing the model does not narrow what users download.

Full build green, 89 tests.

### Notes

Regression from #231 (v1.3.0), which restored manifest deserialization for asset emission and put it on the `CheckStatus` path. Before that `parseManifest` only uploaded the file, so the type was unused since 2023. Anyone upgrading from a pre-1.3.0 plugin hits this on the first run against a Fusion manifest.

dbt Cloud migrates accounts onto Fusion on dbt's schedule, so this is not limited to one customer.

Out of scope, worth a separate issue: `CheckStatus.downloadArtifacts` deserializes each artifact into `ManifestArtifact` / `RunResult` and re-serializes it to the temp file, so any top-level key not declared there is silently dropped from the `manifest.json` users download. The object is discarded immediately and never read, so it is pure overhead, and `ManifestArtifact.parentMap/childMap/groupMap` plus `RunResult.Result.adapterResponse` carry the same over-tight typing that caused this bug.

- closes: https://github.com/kestra-io/plugin-dbt/issues/325
