### PR TITLE
fix(cloud): keep the dbt Cloud token out of toString

### DIFF
--- a/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
+++ b/src/main/java/io/kestra/plugin/dbt/cloud/AbstractDbtCloud.java
@@ -76,6 +76,7 @@ public abstract class AbstractDbtCloud extends Task {
     )
     @NotNull
     @PluginProperty(group = "main", secret = true)
+    @ToString.Exclude
     Property<String> token;
 
     @Schema(title = "The HTTP client configuration")

--- a/src/test/java/io/kestra/plugin/dbt/cloud/CloudTokenRedactionTest.java
+++ b/src/test/java/io/kestra/plugin/dbt/cloud/CloudTokenRedactionTest.java
@@ -1,0 +1,46 @@
+package io.kestra.plugin.dbt.cloud;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.property.Property;
+import io.kestra.core.utils.IdUtils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * `token` is declared on AbstractDbtCloud, which carries a class-level @ToString. Today the concrete tasks
+ * declare their own @ToString and Lombok defaults to callSuper = false, so inherited fields are not printed
+ * and the token does not leak. That safety is incidental: a subclass without @ToString, or callSuper = true,
+ * would start printing a credential. @ToString.Exclude makes it hold by construction, and these pin it.
+ */
+class CloudTokenRedactionTest {
+    private static final String SECRET = "dbtc_a-token-that-must-never-be-printed";
+
+    @Test
+    void checkStatusToStringDoesNotCarryTheToken() {
+        var task = CheckStatus.builder()
+            .id(IdUtils.create())
+            .type(CheckStatus.class.getName())
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue(SECRET))
+            .runId(Property.ofValue("456"))
+            .build();
+
+        assertThat(task.toString(), not(containsString(SECRET)));
+    }
+
+    @Test
+    void triggerRunToStringDoesNotCarryTheToken() {
+        var task = TriggerRun.builder()
+            .id(IdUtils.create())
+            .type(TriggerRun.class.getName())
+            .accountId(Property.ofValue("123"))
+            .token(Property.ofValue(SECRET))
+            .jobId(Property.ofValue("789"))
+            .build();
+
+        assertThat(task.toString(), not(containsString(SECRET)));
+    }
+}


### PR DESCRIPTION
Raised as an aside in the #330 review.

`token` is declared on `AbstractDbtCloud`, which carries a class-level `@ToString`. Nothing leaks today, because both concrete tasks declare their own `@ToString` and Lombok defaults to `callSuper = false`, so inherited fields are not printed. That is incidental: a subclass without `@ToString`, or `callSuper = true`, would print a credential.

`@ToString.Exclude` on the field makes it hold by construction. `CloudTokenRedactionTest` pins it for `CheckStatus` and `TriggerRun`.

Note the review said `CheckStatus` and `TriggerRun` redeclare `token`. They do not, it is declared once on the parent.
